### PR TITLE
Allow public publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "homepage": "https://github.com/PlayerData/react-native-mcu-manager#readme",
   "publishConfig": {
+    "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {


### PR DESCRIPTION
See https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-set-the-access-level-of-the-published-npm-package