### PR TITLE
fix(android): check for nulls in getDefaultAdapter

### DIFF
--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/McuManagerModule.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/McuManagerModule.kt
@@ -7,7 +7,7 @@ import com.facebook.react.bridge.*
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 
 class McuManagerModule(val reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
-    private val bluetoothAdapter: BluetoothAdapter = BluetoothAdapter.getDefaultAdapter()
+    private val bluetoothAdapter: BluetoothAdapter? = BluetoothAdapter.getDefaultAdapter()
 
     var update: DeviceUpdate? = null
 
@@ -19,6 +19,11 @@ class McuManagerModule(val reactContext: ReactApplicationContext) : ReactContext
     fun updateDevice(macAddress: String?, updateFileUriString: String?, updateOptions: ReadableMap, promise: Promise) {
         if (this.update != null) {
             promise.reject("an update is already running")
+            return
+        }
+
+        if (this.bluetoothAdapter == null) {
+            promise.reject("no bluetooth adapter")
             return
         }
 


### PR DESCRIPTION
Android simulator wasn't working because the default adapter was null. This isn't a problem for just running the app though so we have made this nullable and checked that it isn't null before using it in the function below. 

resolves https://github.com/PlayerData/app/issues/2533


---------------------

Self Review:

* [ ] Appropriate test coverage

Smoke Tests:

* [ ] put this patch into node modules on simulator and made sure the app loads
