### PR TITLE
fix: Always call super.init

### DIFF
--- a/ios/McuManager.swift
+++ b/ios/McuManager.swift
@@ -8,6 +8,7 @@ class RNMcuManager: RCTEventEmitter {
     var rejecter: RCTPromiseRejectBlock?
     var updater : DeviceUpdate?
     override init() {
+        super.init()
     }
 
     @objc override func supportedEvents() -> [String] {


### PR DESCRIPTION
Fixes build error:

```
'super.init' isn't called on all paths before returning from initializer
```

Ref https://github.com/PlayerData/app/pull/2876

---------------------

Self Review:

* [ ] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Tested iOS firmware update
