### PR TITLE
Add listener stubs for RN 0.65+

### DIFF
--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/McuManagerModule.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/McuManagerModule.kt
@@ -57,4 +57,14 @@ class McuManagerModule(val reactContext: ReactApplicationContext) : ReactContext
     fun unsetUpdate() {
         this.update = null
     }
+
+    @ReactMethod
+    fun addListener(eventName: String) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Integer) {
+        // Keep: Required for RN built in Event Emitter Calls.
+    }
 }


### PR DESCRIPTION
Removes warnings about event listeners for RN 0.65+:

```
new NativeEventEmitter() was called with a non-null argument without the required addListener/removeListeners method.
```

See https://github.com/software-mansion/react-native-reanimated/pull/2316

There's little documentation, but there doesn't appear to be any need to do anything in the methods.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Run in PlayerData app, and the warning is gone.
