### PR TITLE
Add UpgradeMode to interface

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ buildscript {
   repositories {
     google()
     jcenter()
+    maven { url 'https://jitpack.io' }
   }
 
   dependencies {
@@ -125,6 +126,6 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
 
-  implementation 'no.nordicsemi.android:mcumgr-ble:1.2.0'
+  implementation 'com.github.PlayerData:Android-nRF-Connect-Device-Manager:51832e4e48d6bd7c102ae66e705a8433b9bb7312'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {
-  StyleSheet,
-  View,
-  Text,
   Button,
   FlatList,
+  Modal,
   SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
 } from 'react-native';
+
+import { UpgradeMode } from '@playerdata/react-native-mcu-manager';
 
 import useBluetoothDevices from './useBluetoothDevices';
 import useFilePicker from './useFilePicker';
@@ -15,8 +18,7 @@ import useFirmwareUpdate from './useFirmwareUpdate';
 
 const styles = StyleSheet.create({
   root: {
-    height: '100%',
-    flex: 1,
+    paddingTop: 16,
   },
 
   block: {
@@ -26,59 +28,114 @@ const styles = StyleSheet.create({
   },
 
   list: {
-    flexGrow: 1,
+    padding: 16,
   },
 });
 
 export default function App() {
+  const [devicesListVisible, setDevicesListVisible] = useState(false);
+  const [selectedDeviceName, setSelectedDeviceName] = useState<string | null>(
+    null
+  );
+  const [upgradeMode, setUpgradeMode] = useState<UpgradeMode | undefined>(
+    undefined
+  );
+
   const { devices, error: scanError } = useBluetoothDevices();
   const { selectedFile, filePickerError, pickFile } = useFilePicker();
-  const { bleId, progress, setBleId, startUpdate, state } = useFirmwareUpdate();
+  const { bleId, progress, setBleId, startUpdate, state } = useFirmwareUpdate(
+    upgradeMode
+  );
 
   return (
-    <SafeAreaView style={styles.root}>
-      <Text style={styles.block}>Step 1 - Select Device to Update</Text>
+    <SafeAreaView>
+      <View style={styles.root}>
+        <Text style={styles.block}>Step 1 - Select Device to Update</Text>
 
-      <FlatList
-        data={devices}
-        keyExtractor={({ id }) => id}
-        renderItem={({ item }) => (
-          <View>
-            <Text>{item.name || item.id}</Text>
+        <View style={styles.block}>
+          {bleId && (
+            <>
+              <Text>Selected:</Text>
+              <Text>{selectedDeviceName}</Text>
+            </>
+          )}
+          <Button
+            onPress={() => setDevicesListVisible(true)}
+            title="Select Device"
+          />
+        </View>
 
-            <Button
-              disabled={bleId === item.id}
-              title="Select"
-              onPress={() => setBleId(item.id)}
-            />
-          </View>
-        )}
-        ListHeaderComponent={() => <Text>{scanError}</Text>}
-        style={[styles.block, styles.list]}
-      />
+        <Modal visible={devicesListVisible}>
+          <FlatList
+            contentContainerStyle={styles.list}
+            data={devices}
+            keyExtractor={({ id }) => id}
+            renderItem={({ item }) => (
+              <View>
+                <Text>{item.name || item.id}</Text>
 
-      <Text style={styles.block}>Step 2 - Select Update File</Text>
+                <Button
+                  title="Select"
+                  onPress={() => {
+                    setBleId(item.id);
+                    setSelectedDeviceName(item.name);
+                    setDevicesListVisible(false);
+                  }}
+                />
+              </View>
+            )}
+            ListHeaderComponent={() => <Text>{scanError}</Text>}
+          />
+        </Modal>
 
-      <View style={styles.block}>
-        <Text>
-          {selectedFile?.name} {filePickerError}
-        </Text>
-        <Button onPress={() => pickFile()} title="Pick File" />
-      </View>
+        <Text style={styles.block}>Step 2 - Select Update File</Text>
 
-      <Text style={styles.block}>Step 3 - Update</Text>
+        <View style={styles.block}>
+          <Text>
+            {selectedFile?.name} {filePickerError}
+          </Text>
+          <Button onPress={() => pickFile()} title="Pick File" />
+        </View>
 
-      <View style={styles.block}>
-        <Text>Update Progress / State:</Text>
-        <Text>
-          {state}: {progress}
-        </Text>
+        <Text style={styles.block}>Step 3 - Upgrade Mode</Text>
 
-        <Button
-          disabled={!selectedFile || !bleId}
-          onPress={() => selectedFile && startUpdate(selectedFile.uri)}
-          title="Start Update"
-        />
+        <View style={styles.block}>
+          <Button
+            disabled={upgradeMode === undefined}
+            title="undefined"
+            onPress={() => setUpgradeMode(undefined)}
+          />
+          <Button
+            disabled={upgradeMode === UpgradeMode.TEST_AND_CONFIRM}
+            title="TEST_AND_CONFIRM"
+            onPress={() => setUpgradeMode(UpgradeMode.TEST_AND_CONFIRM)}
+          />
+          <Button
+            disabled={upgradeMode === UpgradeMode.CONFIRM_ONLY}
+            title="CONFIRM_ONLY"
+            onPress={() => setUpgradeMode(UpgradeMode.CONFIRM_ONLY)}
+          />
+          <Button
+            disabled={upgradeMode === UpgradeMode.TEST_ONLY}
+            title="TEST_ONLY"
+            onPress={() => setUpgradeMode(UpgradeMode.TEST_ONLY)}
+          />
+        </View>
+
+        <Text style={styles.block}>Step 4 - Update</Text>
+
+        <View style={styles.block}>
+          <Text>Update Progress / State:</Text>
+          <Text>
+            {state}: {progress}
+          </Text>
+
+          <Button
+            disabled={!selectedFile || !bleId}
+            onPress={() => selectedFile && startUpdate(selectedFile.uri)}
+            title="Start Update"
+          />
+        </View>
       </View>
     </SafeAreaView>
   );

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   Modal,
   SafeAreaView,
+  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -18,13 +19,11 @@ import useFirmwareUpdate from './useFirmwareUpdate';
 
 const styles = StyleSheet.create({
   root: {
-    paddingTop: 16,
+    padding: 16,
   },
 
   block: {
-    marginRight: 16,
     marginBottom: 16,
-    marginLeft: 16,
   },
 
   list: {
@@ -49,7 +48,7 @@ export default function App() {
 
   return (
     <SafeAreaView>
-      <View style={styles.root}>
+      <ScrollView contentContainerStyle={styles.root}>
         <Text style={styles.block}>Step 1 - Select Device to Update</Text>
 
         <View style={styles.block}>
@@ -136,7 +135,7 @@ export default function App() {
             title="Start Update"
           />
         </View>
-      </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }

--- a/example/src/useBluetoothDevices.ts
+++ b/example/src/useBluetoothDevices.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { BleManager, Device } from 'react-native-ble-plx';
-import { uniqBy } from 'lodash';
+import { sortBy, uniqBy } from 'lodash';
 
 const useBluetoothDevices = () => {
   const [bleManager] = useState(() => new BleManager());
@@ -19,7 +19,7 @@ const useBluetoothDevices = () => {
         if (!scannedDevice) return;
 
         setDevices((oldDevices) =>
-          uniqBy([...oldDevices, scannedDevice], 'id')
+          sortBy(uniqBy([...oldDevices, scannedDevice], 'id'), 'name')
         );
       }
     );

--- a/example/src/useFirmwareUpdate.ts
+++ b/example/src/useFirmwareUpdate.ts
@@ -3,9 +3,10 @@ import { useState, useEffect } from 'react';
 import McuManager, {
   ProgressEvent,
   UploadEvents,
+  UpgradeMode,
 } from '@playerdata/react-native-mcu-manager';
 
-const useFirmwareUpdate = () => {
+const useFirmwareUpdate = (upgradeMode?: UpgradeMode) => {
   const [bleId, setBleId] = useState<string | null>(null);
   const [progress, setProgress] = useState(0);
   const [state, setState] = useState('');
@@ -40,6 +41,7 @@ const useFirmwareUpdate = () => {
   const startUpdate = (updateFileUri: string): Promise<void> =>
     McuManager.updateDevice(bleId!, updateFileUri, {
       estimatedSwapTime: 60,
+      upgradeMode,
     }).catch((e: Error) => {
       setState(e.message);
     });

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -38,7 +38,9 @@
     /* Module Resolution Options */
     "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "paths": {
+      "@playerdata/react-native-mcu-manager": ["../src/index"]
+    },                                        /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */

--- a/ios/DeviceUpdate.swift
+++ b/ios/DeviceUpdate.swift
@@ -1,5 +1,11 @@
 import McuManager
 
+enum JSUpgradeMode: Int {
+    case TEST_AND_CONFIRM = 1
+    case CONFIRM_ONLY = 2
+    case TEST_ONLY = 3
+}
+
 class DeviceUpdate{
     let deviceUUID: UUID
     var file : Data?
@@ -38,6 +44,7 @@ class DeviceUpdate{
 
         self.dfuManager!.logDelegate = self.logDelegate
         self.dfuManager!.estimatedSwapTime = estimatedSwapTime
+        self.dfuManager!.mode = self.getMode();
 
         // Start the firmware upgrade with the image data
         do {
@@ -56,6 +63,25 @@ class DeviceUpdate{
         self.file = nil;
         if let transport = self.bleTransport {
             transport.close();
+        }
+    }
+
+    private func getMode() -> FirmwareUpgradeMode {
+        if self.options["upgradeMode"] == nil {
+            return FirmwareUpgradeMode.testAndConfirm
+        }
+
+        guard let jsMode = JSUpgradeMode(rawValue: self.options["upgradeMode"] as! Int) else {
+            return FirmwareUpgradeMode.testAndConfirm
+        }
+
+        switch jsMode {
+        case .TEST_AND_CONFIRM:
+            return FirmwareUpgradeMode.testAndConfirm
+        case .TEST_ONLY:
+            return FirmwareUpgradeMode.testOnly
+        case .CONFIRM_ONLY:
+            return FirmwareUpgradeMode.confirmOnly
         }
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,10 +1,38 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
 
-interface UpdateOptions {
-  /*
+export enum UpgradeMode {
+  /**
+   * This mode is the default and recommended mode for performing upgrades due to it's ability to
+   * recover from a bad firmware upgrade. The process for this mode is upload, test, reset, confirm.
+   */
+  TEST_AND_CONFIRM = 1,
+
+  /**
+   * This mode is not recommended. If the device fails to boot into the new image, it will not be able
+   * to recover and will need to be re-flashed. The process for this mode is upload, confirm, reset.
+   */
+  CONFIRM_ONLY = 2,
+
+  /**
+   * This mode is useful if you want to run tests on the new image running before confirming it
+   * manually as the primary boot image. The process for this mode is upload, test, reset.
+   */
+  TEST_ONLY = 3,
+}
+
+export interface UpdateOptions {
+  /**
    * The estimated time, in seconds, that it takes for the target device to swap to the updated image.
    */
   estimatedSwapTime: number;
+
+  /**
+   * McuManager firmware upgrades can actually be performed in few different ways.
+   * These different upgrade modes determine the commands sent after the upload step.
+   *
+   * @see UpgradeMode
+   */
+  upgradeMode?: UpgradeMode;
 }
 
 type McuManagerType = {


### PR DESCRIPTION
Allows the upgrade mode to be selected when upgrading.

Also includes minor changes to the example app:
* Allow selecting of upgrade mode
* Move device selection into a modal
* Sort devices by name

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Tested in example app on Android
* [x] Tested in example app on iOS
