### PR TITLE
Upgrade iOSMcuManagerLibrary

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,8 +11,8 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - McuManager (0.12.0):
-    - SwiftCBOR (= 0.4.3)
+  - iOSMcuManagerLibrary (1.1.0):
+    - SwiftCBOR (= 0.4.4)
   - MultiplatformBleAdapter (0.1.9)
   - RCT-Folly (2021.06.28.00-v2):
     - boost
@@ -229,7 +229,7 @@ PODS:
   - react-native-get-random-values (1.8.0):
     - React-Core
   - react-native-mcu-manager (0.0.1-development):
-    - McuManager (~> 0.12.0)
+    - iOSMcuManagerLibrary (~> 1.1.0)
     - React-Core
   - React-perflogger (0.68.1)
   - React-RCTActionSheet (0.68.1):
@@ -296,7 +296,7 @@ PODS:
     - React-jsi (= 0.68.1)
     - React-logger (= 0.68.1)
     - React-perflogger (= 0.68.1)
-  - SwiftCBOR (0.4.3)
+  - SwiftCBOR (0.4.4)
   - Yoga (1.14.0)
 
 DEPENDENCIES:
@@ -341,7 +341,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - fmt
-    - McuManager
+    - iOSMcuManagerLibrary
     - MultiplatformBleAdapter
     - SwiftCBOR
 
@@ -424,7 +424,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 371350f24afa87b6aba606972ec959dcd4a95c9a
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  McuManager: 04fbec94566eaaf5508175246b1d5b0c5f1b83dd
+  iOSMcuManagerLibrary: 64853befc4e6ff100809069f308cbf6ba38ec033
   MultiplatformBleAdapter: 5a6a897b006764392f9cef785e4360f54fb9477d
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 00581111c53531e39e3c6346ef0d2c0cf52a5a37
@@ -442,7 +442,7 @@ SPEC CHECKSUMS:
   react-native-ble-plx: f10240444452dfb2d2a13a0e4f58d7783e92d76e
   react-native-document-picker: 226068006be4c52f8ef7f32d855ee025a12e9e64
   react-native-get-random-values: a6ea6a8a65dc93e96e24a11105b1a9c8cfe1d72a
-  react-native-mcu-manager: c249a73ca38f2152679e53aca40d08a4a26638d6
+  react-native-mcu-manager: 0b8b4258106b8a3c2888a1521a6ae3d5634ba463
   React-perflogger: 30ab8d6db10e175626069e742eead3ebe8f24fd5
   React-RCTActionSheet: 4b45da334a175b24dabe75f856b98fed3dfd6201
   React-RCTAnimation: d6237386cb04500889877845b3e9e9291146bc2e
@@ -455,7 +455,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 9e344c840176b0af9c84d5019eb4fed8b3c105a1
   React-runtimeexecutor: 7285b499d0339104b2813a1f58ad1ada4adbd6c0
   ReactCommon: bf2888a826ceedf54b99ad1b6182d1bc4a8a3984
-  SwiftCBOR: c7d740966575e0fd5d971466de2b6776db3f10c3
+  SwiftCBOR: ce5354ec8b660da2d6fc754462881119dbe1f963
   Yoga: 17cd9a50243093b547c1e539c749928dd68152da
 
 PODFILE CHECKSUM: c253f0de47435bd522e26588156f2650ee8d47f0

--- a/ios/DeviceUpgrade.swift
+++ b/ios/DeviceUpgrade.swift
@@ -1,4 +1,4 @@
-import McuManager
+import iOSMcuManagerLibrary
 
 enum JSUpgradeMode: Int {
     case TEST_AND_CONFIRM = 1

--- a/react-native-mcu-manager.podspec
+++ b/react-native-mcu-manager.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/PlayerData/react-native-mcu-manager.git", :tag => "#{s.version}" }
 
   s.dependency "React-Core"
-  s.dependency "McuManager", "~> 0.12.0"
+  s.dependency "iOSMcuManagerLibrary", "~> 1.1.0"
 
 end


### PR DESCRIPTION
Upstream `McuManager` has been renamed to `iOSMcuManagerLibrary`

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Tested upgrade on iOS
