### PR TITLE
chore(android): switch back to official mcumgr library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,6 @@ buildscript {
   repositories {
     google()
     jcenter()
-    maven { url 'https://jitpack.io' }
   }
 
   dependencies {
@@ -126,6 +125,6 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
 
-  implementation 'com.github.PlayerData:Android-nRF-Connect-Device-Manager:51832e4e48d6bd7c102ae66e705a8433b9bb7312'
+  implementation 'no.nordicsemi.android:mcumgr-ble:1.3.1'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
Fixes #23 

Upstream has now released a version including the patch for running updates on devices on the correct image already

---------------------

Self Review:

* [ ] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [x] ran app on android against this branch and updated a device
