### PR TITLE
Correct cancelUpgrade function name

### DIFF
--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/McuManagerModule.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/McuManagerModule.kt
@@ -42,7 +42,7 @@ class McuManagerModule(val reactContext: ReactApplicationContext) : ReactContext
     }
 
     @ReactMethod
-    fun cancel(id: String) {
+    fun cancelUpgrade(id: String) {
         if (!upgrades.contains(id)){
             Log.w(this.TAG,"can't cancel update ID ($id} not present")
             return

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -43,7 +43,7 @@ export default function App() {
 
   const { devices, error: scanError } = useBluetoothDevices();
   const { selectedFile, filePickerError, pickFile } = useFilePicker();
-  const { progress, runUpdate, state } = useFirmwareUpdate(
+  const { cancelUpdate, runUpdate, progress, state } = useFirmwareUpdate(
     selectedDeviceId,
     selectedFile?.uri || null,
     upgradeMode
@@ -136,6 +136,12 @@ export default function App() {
             disabled={!selectedFile || !selectedDeviceId}
             onPress={() => selectedFile && runUpdate()}
             title="Start Update"
+          />
+
+          <Button
+            disabled={!selectedFile || !selectedDeviceId}
+            onPress={() => cancelUpdate()}
+            title="Cancel Update"
           />
         </View>
       </ScrollView>

--- a/example/src/useFirmwareUpdate.ts
+++ b/example/src/useFirmwareUpdate.ts
@@ -58,7 +58,13 @@ const useFirmwareUpdate = (
     }
   };
 
-  return { progress, runUpdate, state };
+  const cancelUpdate = (): void => {
+    if (!upgradeRef.current) return;
+
+    upgradeRef.current.cancel();
+  };
+
+  return { progress, runUpdate, state, cancelUpdate };
 };
 
 export default useFirmwareUpdate;


### PR DESCRIPTION
Ref https://github.com/PlayerData/app/issues/4749

The `cancelUpgrade` function on Android is incorrectly called `cancel`, meaning it isn't available to JavaScript.

Also adds a cancel button to the example app to prove this.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Pressing the cancel button on Android works
