### PR TITLE
Safer promise check

### DIFF
--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
@@ -40,11 +40,11 @@ class DeviceUpgrade(
         doUpdate(updateFileUri)
     }
 
-    fun withSafePromise(block: (promise: Promise) -> Unit) {
+    @Synchronized fun withSafePromise(block: (promise: Promise) -> Unit) {
         val promise = unsafePromise
         if (promise != null && !promiseComplete){
-            block(promise)
             promiseComplete = true
+            block(promise)
         }
     }
 


### PR DESCRIPTION
React native `null`s out the underlying promise reject/resolve objects once a promise has been resolved/rejected.

We're seeing a race between `cancel` calls that causes the promise to be resolved/rejected twice.

By giving `withSafePromise` a `@Synchronized` annotation, we ensure it is only called by one thread per instance of `DeviceUpgrade`.

Strictly, changing the order of the block call / promiseComplete call is unnecessary, but it feels safer this way round.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I can run multiple upgrades in parallel with no cancelling issues
