### PR TITLE
Expose ability to erase secondary image

### DIFF
--- a/ios/McuManager.m
+++ b/ios/McuManager.m
@@ -13,6 +13,13 @@ RCT_EXTERN_METHOD(
                   )
 
 RCT_EXTERN_METHOD(
+                  eraseImage:
+                  NSString
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject
+                  )
+
+RCT_EXTERN_METHOD(
                   createUpgrade:
                   NSString
                   bleId: NSString

--- a/ios/McuManager.swift
+++ b/ios/McuManager.swift
@@ -1,5 +1,6 @@
 import os
 import CoreBluetooth
+import iOSMcuManagerLibrary
 
 
 @objc(RNMcuManager)
@@ -17,6 +18,27 @@ class RNMcuManager: RCTEventEmitter {
             "uploadProgress",
             "upgradeStateChanged"
         ]
+    }
+
+    @objc
+    func eraseImage(_ bleId: String, resolver resolve: @escaping RCTPromiseResolveBlock, rejecter reject: @escaping RCTPromiseRejectBlock) -> Void {
+        guard let bleUuid = UUID(uuidString: bleId) else {
+            let error = NSError(domain: "", code: 200, userInfo: nil)
+            return reject("error", "failed to parse uuid", error);
+        }
+
+        let bleTransport = McuMgrBleTransport(bleUuid)
+        let imageManager = ImageManager(transporter: bleTransport)
+
+        imageManager.erase { (response: McuMgrResponse?, err: Error?) in
+            if (err != nil) {
+                reject("ERASE_ERR", err?.localizedDescription, err)
+                return
+            }
+
+            resolve(nil)
+            return
+        }
     }
 
     @objc

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,15 @@
+import { NativeModules } from 'react-native';
+
+const { McuManager } = NativeModules;
+
 import Upgrade, {
   FirmwareUpgradeState,
   UpgradeOptions,
   UpgradeMode,
 } from './Upgrade';
+
+export const eraseImage = McuManager.eraseImage as (
+  bleId: string
+) => Promise<void>;
 
 export { Upgrade, FirmwareUpgradeState, UpgradeOptions, UpgradeMode };


### PR DESCRIPTION
Ref https://github.com/PlayerData/edge-v2/issues/542

Exposes the ability to erase an image.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Tested on Android
* [x] Tested on iOS
