### PR TITLE
Allow native module to be undefined (for test mocking)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,7 @@ import Upgrade, {
   UpgradeMode,
 } from './Upgrade';
 
-export const eraseImage = McuManager.eraseImage as (
+export const eraseImage = McuManager?.eraseImage as (
   bleId: string
 ) => Promise<void>;
 


### PR DESCRIPTION
`McuManager` can be undefined in tests.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I can now mock correctly.
