### PR TITLE
Request disconnect after erase operation

### DIFF
--- a/ios/McuManager.swift
+++ b/ios/McuManager.swift
@@ -31,6 +31,8 @@ class RNMcuManager: RCTEventEmitter {
         let imageManager = ImageManager(transporter: bleTransport)
 
         imageManager.erase { (response: McuMgrResponse?, err: Error?) in
+            bleTransport.close()
+
             if (err != nil) {
                 reject("ERASE_ERR", err?.localizedDescription, err)
                 return


### PR DESCRIPTION
Previously we were holding the connection, which causes timeouts if we then attempt to connect to more peripherals.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Tested on iOS with Edge upgrades
