### PR TITLE
fix(android): bump minSdkVersion from 16 to 21

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,7 +29,7 @@ android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
   buildToolsVersion getExtOrDefault('buildToolsVersion')
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
<!-- Motivation -->
ref: https://github.com/PlayerData/app/issues/5857
<!-- Overview -->
Getting the following error when trying to detox build for android. This should fix it.

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':playerdata_react-native-mcu-manager:processDebugAndroidTestManifest'.
> Manifest merger failed : uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.71.3] /Users/williamflemmer/.gradle/caches/transforms-3/d812b33ccc5e387336320351cd36011d/transformed/jetified-react-android-0.71.3-debug/AndroidManifest.xml as the library might be using APIs not available in 16
        Suggestion: use a compatible library with a minSdk of at most 16,
                or increase this project's minSdk version to at least 21,
                or use tools:overrideLibrary="com.facebook.react" to force usage (may lead to runtime failures)

```

---------------------

Self Review:

* [ ] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [x] CI passes
