### PR TITLE
fix(ios): revert bump of iosmcumgr

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -11,7 +11,7 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.68.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - iOSMcuManagerLibrary (1.3.2):
+  - iOSMcuManagerLibrary (1.1.0):
     - SwiftCBOR (= 0.4.4)
   - MultiplatformBleAdapter (0.1.9)
   - RCT-Folly (2021.06.28.00-v2):
@@ -229,7 +229,7 @@ PODS:
   - react-native-get-random-values (1.8.0):
     - React-Core
   - react-native-mcu-manager (0.0.1-development):
-    - iOSMcuManagerLibrary (~> 1.3.2)
+    - iOSMcuManagerLibrary (~> 1.1.0)
     - React-Core
   - React-perflogger (0.68.1)
   - React-RCTActionSheet (0.68.1):
@@ -424,7 +424,7 @@ SPEC CHECKSUMS:
   FBReactNativeSpec: 371350f24afa87b6aba606972ec959dcd4a95c9a
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  iOSMcuManagerLibrary: 2dbc3ef6fed190e1c1db2c88d8dacdde8b6dda0d
+  iOSMcuManagerLibrary: 64853befc4e6ff100809069f308cbf6ba38ec033
   MultiplatformBleAdapter: 5a6a897b006764392f9cef785e4360f54fb9477d
   RCT-Folly: 4d8508a426467c48885f1151029bc15fa5d7b3b8
   RCTRequired: 00581111c53531e39e3c6346ef0d2c0cf52a5a37
@@ -442,7 +442,7 @@ SPEC CHECKSUMS:
   react-native-ble-plx: f10240444452dfb2d2a13a0e4f58d7783e92d76e
   react-native-document-picker: 2b8f18667caee73a96708a82b284a4f40b30a156
   react-native-get-random-values: a6ea6a8a65dc93e96e24a11105b1a9c8cfe1d72a
-  react-native-mcu-manager: a7166f610e90374fdff1b80c6db17b9bb7f754b5
+  react-native-mcu-manager: 0b8b4258106b8a3c2888a1521a6ae3d5634ba463
   React-perflogger: 30ab8d6db10e175626069e742eead3ebe8f24fd5
   React-RCTActionSheet: 4b45da334a175b24dabe75f856b98fed3dfd6201
   React-RCTAnimation: d6237386cb04500889877845b3e9e9291146bc2e

--- a/ios/DeviceUpgrade.swift
+++ b/ios/DeviceUpgrade.swift
@@ -57,14 +57,12 @@ class DeviceUpgrade {
             self.dfuManager = FirmwareUpgradeManager(transporter: self.bleTransport!, delegate: self)
 
             let estimatedSwapTime: TimeInterval = self.options["estimatedSwapTime"] as! TimeInterval
-            let config = FirmwareUpgradeConfiguration(
-                estimatedSwapTime: estimatedSwapTime
-            )
 
             self.dfuManager!.logDelegate = self.logDelegate
+            self.dfuManager!.estimatedSwapTime = estimatedSwapTime
             self.dfuManager!.mode = self.getMode();
 
-            try self.dfuManager!.start(data: file as Data, using: config)
+            try self.dfuManager!.start(data: file as Data)
         } catch {
             reject(error.localizedDescription, error.localizedDescription, error)
         }
@@ -158,8 +156,6 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
             return "CONFIRM"
         case .success:
             return "SUCCESS"
-        case .requestMcuMgrParameters:
-            return "REQUEST_MCU_MGR_PARAMETERS"
         default:
             return "UNKNOWN"
         }

--- a/react-native-mcu-manager.podspec
+++ b/react-native-mcu-manager.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/PlayerData/react-native-mcu-manager.git", :tag => "#{s.version}" }
 
   s.dependency "React-Core"
-  s.dependency "iOSMcuManagerLibrary", "~> 1.3.2"
+  s.dependency "iOSMcuManagerLibrary", "~> 1.1.0"
 
 end


### PR DESCRIPTION
2f7be14ffc25bab9bcd15578ec3f2ccaafd106a2 and 8dd0b6a8e0363556a6c31e12737684c1426d9ccc

The issues with firmware upgrades appear to be coming from a query of mcmgr parameters on the device that is expected to fail but the library doesn't handle the failure correctly and crashes. recent prs to the libary suggest they might be trying to fix this issue but these haven't been published as a version yet and pr descriptions read like its an ongoing not fixed issue.

https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/pull/148/files


---------------------

Self Review:

* [ ] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [x] updated an edge using ipad version running on mac
* [x] update between factory test versions using example app
