### PR TITLE
Adding prebuild and example apps build steps 

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build and Release
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -24,9 +24,60 @@ jobs:
 
       - name: Build
         run: npm run build
+        
+  android-example:
+      name: Android example app
+      runs-on: ubuntu-latest
+      needs: build
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Making sure the android example app builds
+        run: |
+          npm install
+          cd example
+          npx expo prebuild
+          cd android
+          ./gradlew build
+          
+  ios-example:
+      name: iOS example app
+      runs-on: macos-latest
+      needs: build
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Making sure the ios example app builds
+        run: |
+          npm install
+          cd example
+          npx expo prebuild
+          cd ios
+          xcodebuild build -workspace reactnativemcumanagerexample.xcworkspace -scheme reactnativemcumanagerexample CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+      
+  release:
+    name: Release
+    needs: [android-example, ios-example]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
 
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+          node-version: 18
+          
+    - name: Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      run: npx semantic-release

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@config-plugins/react-native-ble-plx": "^7.0.0",
         "expo": "^49.0.0",
+        "expo-constants": "~14.5.0",
         "expo-location": "~16.1.0",
         "expo-splash-screen": "~0.20.5",
         "expo-status-bar": "~1.6.0",
@@ -7862,7 +7863,7 @@
         "url-parse": "^1.5.9"
       }
     },
-    "node_modules/expo-constants": {
+    "node_modules/expo-asset/node_modules/expo-constants": {
       "version": "14.4.2",
       "resolved": "https://npm.playerdata.co.uk/expo-constants/-/expo-constants-14.4.2.tgz",
       "integrity": "sha512-nOB122DOAjk+KrJT69lFQAoYVQGQjFHSigCPVBzVdko9S1xGsfiOH9+X5dygTsZTIlVLpQJDdmZ7ONiv3i+26w==",
@@ -7873,6 +7874,199 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-constants": {
+      "version": "14.5.1",
+      "resolved": "https://npm.playerdata.co.uk/expo-constants/-/expo-constants-14.5.1.tgz",
+      "integrity": "sha512-06OKXQmKI0vuje++6lm7w1kO3rKsZAHio/4d9hwQuVAtExJ6RM92BnpzkDAV16ZheVN/FHKzNyY1BYLqXfujMw==",
+      "dependencies": {
+        "@expo/config": "~8.2.0",
+        "uuid": "^3.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://npm.playerdata.co.uk/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/config": {
+      "version": "8.2.1",
+      "resolved": "https://npm.playerdata.co.uk/@expo/config/-/config-8.2.1.tgz",
+      "integrity": "sha512-15XjV0WrSb5hChRM5pAEK5uyh55njfgFOEZpov3YKYBeMd9D6QT/azWWqnaFuuCWKzgzyxD9HaYgGo5VbnOU1g==",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~7.3.0",
+        "@expo/config-types": "^49.0.0-alpha.1",
+        "@expo/json-file": "^8.2.37",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "semver": "7.5.3",
+        "slugify": "^1.3.4",
+        "sucrase": "^3.20.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/@expo/config-plugins": {
+      "version": "7.3.1",
+      "resolved": "https://npm.playerdata.co.uk/@expo/config-plugins/-/config-plugins-7.3.1.tgz",
+      "integrity": "sha512-TkDtAP3P/rrjhr7GBQtyYH/l1SQUGAO/gByBCwHjfRa4RIPFs+iiq7hocytAl+oSmVsB28ipZCC3O1IPg1OZ7g==",
+      "dependencies": {
+        "@expo/config-types": "^49.0.0-alpha.1",
+        "@expo/json-file": "~8.2.37",
+        "@expo/plist": "^0.0.20",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "@react-native/normalize-color": "^2.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.1",
+        "find-up": "~5.0.0",
+        "getenv": "^1.0.0",
+        "glob": "7.1.6",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.3",
+        "slash": "^3.0.0",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://npm.playerdata.co.uk/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/expo-constants/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://npm.playerdata.co.uk/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/expo-constants/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://npm.playerdata.co.uk/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/expo-constants/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://npm.playerdata.co.uk/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/expo-constants/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://npm.playerdata.co.uk/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/expo-constants/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://npm.playerdata.co.uk/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/expo-constants/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://npm.playerdata.co.uk/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-constants/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://npm.playerdata.co.uk/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-constants/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://npm.playerdata.co.uk/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/expo-constants/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://npm.playerdata.co.uk/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-constants/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://npm.playerdata.co.uk/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/expo-constants/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://npm.playerdata.co.uk/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/expo-file-system": {
       "version": "15.4.4",
@@ -8049,6 +8243,18 @@
       "version": "1.6.0",
       "resolved": "https://npm.playerdata.co.uk/expo-status-bar/-/expo-status-bar-1.6.0.tgz",
       "integrity": "sha512-e//Oi2WPdomMlMDD3skE4+1ZarKCJ/suvcB4Jo/nO427niKug5oppcPNYO+csR6y3ZglGuypS+3pp/hJ+Xp6fQ=="
+    },
+    "node_modules/expo/node_modules/expo-constants": {
+      "version": "14.4.2",
+      "resolved": "https://npm.playerdata.co.uk/expo-constants/-/expo-constants-14.4.2.tgz",
+      "integrity": "sha512-nOB122DOAjk+KrJT69lFQAoYVQGQjFHSigCPVBzVdko9S1xGsfiOH9+X5dygTsZTIlVLpQJDdmZ7ONiv3i+26w==",
+      "dependencies": {
+        "@expo/config": "~8.1.0",
+        "uuid": "^3.3.2"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
     },
     "node_modules/fast-base64-decode": {
       "version": "1.0.0",

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,8 @@
     "react-native-ble-plx": "^3.1.1",
     "react-native-document-picker": "^9.0.1",
     "react-native-get-random-values": "^1.8.0",
-    "react-native-toast-message": "^2.1.7"
+    "react-native-toast-message": "^2.1.7",
+    "expo-constants": "~14.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
<!-- Motivation -->
We want to make sure the library does work or at least compiles correctly when added to an app by checking the prebuilt android and ios apps

<!-- Overview -->
Closes `Improve CI coverage for React Native MCU Mgr #71 `
I tried passing along the context of the first step but it would require so much stuff to be uploaded or cached across instances that it seems just faster to re-checkout and re-install the deps.

---------------------

Self Review:

* [ ] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [ ]
