### PR TITLE
fix(android): Ensure MCUMgr errors always have a message

### DIFF
--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
@@ -11,6 +11,7 @@ import expo.modules.kotlin.modules.ModuleDefinition
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
 import io.runtime.mcumgr.ble.McuMgrBleTransport
+import io.runtime.mcumgr.exception.McuMgrException
 import io.runtime.mcumgr.managers.ImageManager
 
 private const val MODULE_NAME = "ReactNativeMcuManager"
@@ -52,8 +53,8 @@ class ReactNativeMcuManagerModule : Module() {
         imageManager.erase()
 
         promise.resolve(null)
-      } catch (e: Throwable) {
-        promise.reject(CodedException(e))
+      } catch (e: McuMgrException) {
+        promise.reject(ReactNativeMcuMgrException.fromMcuMgrException(e))
       }
     }
 
@@ -87,7 +88,7 @@ class ReactNativeMcuManagerModule : Module() {
 
     AsyncFunction("runUpgrade") { id: String, promise: Promise ->
       if (!upgrades.contains(id)) {
-        promise.reject(CodedException("update ID not present"))
+        promise.reject(CodedException("UPGRADE_ID_MISSING", "Upgrade ID $id not present", null))
       }
 
       upgrades[id]!!.startUpgrade(promise)
@@ -95,7 +96,7 @@ class ReactNativeMcuManagerModule : Module() {
 
     AsyncFunction("cancelUpgrade") { id: String, promise: Promise ->
       if (!upgrades.contains(id)) {
-        Log.w(TAG, "can't cancel update ID ($id} not present")
+        Log.w(TAG, "Can't cancel update ID ($id} not present")
         return@AsyncFunction
       }
 
@@ -104,7 +105,7 @@ class ReactNativeMcuManagerModule : Module() {
 
     Function("destroyUpgrade") { id: String ->
       if (!upgrades.contains(id)) {
-        Log.w(TAG, "can't destroy update ID ($id} not present")
+        Log.w(TAG, "Can't destroy update ID ($id} not present")
         return@Function
       }
 

--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuMgrException.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuMgrException.kt
@@ -1,0 +1,53 @@
+package uk.co.playerdata.reactnativemcumanager
+
+import expo.modules.kotlin.exception.CodedException
+import io.runtime.mcumgr.ble.exception.McuMgrBluetoothDisabledException
+import io.runtime.mcumgr.ble.exception.McuMgrDisconnectedException
+import io.runtime.mcumgr.ble.exception.McuMgrNotSupportedException
+import io.runtime.mcumgr.exception.InsufficientMtuException
+import io.runtime.mcumgr.exception.McuMgrCoapException
+import io.runtime.mcumgr.exception.McuMgrErrorException
+import io.runtime.mcumgr.exception.McuMgrException
+import io.runtime.mcumgr.exception.McuMgrTimeoutException
+
+class ReactNativeMcuMgrException private constructor(
+    code: String, message: String?, cause: Throwable?
+) : CodedException(code, message, cause) {
+
+    companion object {
+        private fun getCode(e: McuMgrException): String {
+            return when (e) {
+                is McuMgrBluetoothDisabledException -> return "MCU_MGR_BLUETOOTH_DISABLED"
+                is McuMgrDisconnectedException -> return "MCU_MGR_DISCONNECTED"
+                is McuMgrNotSupportedException -> return "MCU_MGR_NOT_SUPPORTED"
+                is InsufficientMtuException -> return "MCU_MGR_INSUFFICIENT_MTU"
+                is McuMgrCoapException -> return "MCU_MGR_COAP"
+                is McuMgrErrorException -> return "MCU_MGR_ERROR_${e.code}"
+                is McuMgrTimeoutException -> return "MCU_MGR_TIMEOUT"
+                else -> "UNEXPECTED_MCU_MGR_EXCEPTION"
+            }
+        }
+
+        private fun getMessage(e: McuMgrException): String {
+            return when (e) {
+                is McuMgrBluetoothDisabledException -> return "Bluetooth disabled"
+                is McuMgrDisconnectedException -> return "Device disconnected"
+                is McuMgrNotSupportedException -> return "Device not supported by MCUMgr"
+                is McuMgrTimeoutException -> return "MCUMgr timeout"
+                else -> {
+                    if (e.localizedMessage != null) {
+                        return e.localizedMessage
+                    } else if (e.message != null) {
+                        return e.message!!
+                    } else {
+                        return e.toString()
+                    }
+                }
+            }
+        }
+
+        fun fromMcuMgrException(e: McuMgrException): ReactNativeMcuMgrException {
+            return ReactNativeMcuMgrException(this.getCode(e), this.getMessage(e), e)
+        }
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/PlayerData/react-native-mcu-manager/issues/99

Frustratingly, some of the Nordic defined errors do not have messages. This causes react native to throw "Value is null, expected a String".


---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Reset MCU during erase step. See error message rather than crash
