### PR TITLE
Updating iOS MCU lib

### DIFF
--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
@@ -14,19 +14,19 @@ import io.runtime.mcumgr.exception.McuMgrException
 import java.io.IOException
 
 val UpgradeModes =
-    mapOf(
-        1 to FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM,
-        2 to FirmwareUpgradeManager.Mode.CONFIRM_ONLY,
-        3 to FirmwareUpgradeManager.Mode.TEST_ONLY
-    )
+        mapOf(
+                1 to FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM,
+                2 to FirmwareUpgradeManager.Mode.CONFIRM_ONLY,
+                3 to FirmwareUpgradeManager.Mode.TEST_ONLY
+        )
 
 class DeviceUpgrade(
-    private val id: String,
-    device: BluetoothDevice,
-    private val context: Context,
-    private val updateFileUri: Uri,
-    private val updateOptions: UpdateOptions,
-    private val manager: ReactNativeMcuManagerModule
+        private val id: String,
+        device: BluetoothDevice,
+        private val context: Context,
+        private val updateFileUri: Uri,
+        private val updateOptions: UpdateOptions,
+        private val manager: ReactNativeMcuManagerModule
 ) : FirmwareUpgradeCallback {
     private val TAG = "DeviceUpdate"
     private var lastNotification = -1
@@ -54,13 +54,7 @@ class DeviceUpgrade(
         disconnectDevice()
         Log.v(this.TAG, "Cancel")
         withSafePromise { promise ->
-            promise.reject(
-                CodedException(
-                    "UPGRADE_CANCELLED",
-                    "Upgrade cancelled",
-                    null
-                )
-            )
+            promise.reject(CodedException("UPGRADE_CANCELLED", "Upgrade cancelled", null))
         }
     }
 
@@ -93,11 +87,7 @@ class DeviceUpgrade(
             disconnectDevice()
             Log.v(this.TAG, "mcu exception")
             withSafePromise { promise ->
-                promise.reject(
-                    ReactNativeMcuMgrException.fromMcuMgrException(
-                        e
-                    )
-                )
+                promise.reject(ReactNativeMcuMgrException.fromMcuMgrException(e))
             }
         }
     }
@@ -105,8 +95,8 @@ class DeviceUpgrade(
     override fun onUpgradeStarted(controller: FirmwareUpgradeController) {}
 
     override fun onStateChanged(
-        prevState: FirmwareUpgradeManager.State,
-        newState: FirmwareUpgradeManager.State
+            prevState: FirmwareUpgradeManager.State,
+            newState: FirmwareUpgradeManager.State
     ) {
         val stateMap: Map<String, Any?> = mapOf("id" to id, "state" to newState.name)
         manager.upgradeStateCB(stateMap)
@@ -120,24 +110,14 @@ class DeviceUpgrade(
     override fun onUpgradeFailed(state: FirmwareUpgradeManager.State, error: McuMgrException) {
         disconnectDevice()
         withSafePromise { promise ->
-            promise.reject(
-                ReactNativeMcuMgrException.fromMcuMgrException(
-                    error
-                )
-            )
+            promise.reject(ReactNativeMcuMgrException.fromMcuMgrException(error))
         }
     }
 
     override fun onUpgradeCanceled(state: FirmwareUpgradeManager.State) {
         disconnectDevice()
         withSafePromise { promise ->
-            promise.reject(
-                CodedException(
-                    "UPGRADE_CANCELLED",
-                    "Upgrade cancelled",
-                    null
-                )
-            )
+            promise.reject(CodedException("UPGRADE_CANCELLED", "Upgrade cancelled", null))
         }
     }
 

--- a/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuMgrException.kt
+++ b/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuMgrException.kt
@@ -10,9 +10,9 @@ import io.runtime.mcumgr.exception.McuMgrErrorException
 import io.runtime.mcumgr.exception.McuMgrException
 import io.runtime.mcumgr.exception.McuMgrTimeoutException
 
-class ReactNativeMcuMgrException private constructor(
-    code: String, message: String?, cause: Throwable?
-) : CodedException(code, message, cause) {
+class ReactNativeMcuMgrException
+private constructor(code: String, message: String?, cause: Throwable?) :
+        CodedException(code, message, cause) {
 
     companion object {
         private fun getCode(e: McuMgrException): String {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -127,7 +127,7 @@ export default function App() {
         <Text style={styles.block}>Step 4 - Update</Text>
 
         <View style={styles.block}>
-          <Text>Update Progress / State:</Text>
+          <Text>State / Update Progress:</Text>
           <Text>
             {state}: {progress}
           </Text>

--- a/example/src/useBluetoothDevices.ts
+++ b/example/src/useBluetoothDevices.ts
@@ -27,7 +27,7 @@ const useBluetoothDevices = () => {
           deviceIdRef.current.push(scannedDevice.id);
 
           setDevices((oldDevices) =>
-            sortBy(uniqBy([...oldDevices, scannedDevice], 'id'), 'name')
+            sortBy(uniqBy([scannedDevice, ...oldDevices], 'id'), 'name')
           );
         }
       )

--- a/ios/DeviceUpgrade.swift
+++ b/ios/DeviceUpgrade.swift
@@ -2,209 +2,218 @@ import ExpoModulesCore
 import iOSMcuManagerLibrary
 
 enum JSUpgradeMode: Int {
-    case TEST_AND_CONFIRM = 1
-    case CONFIRM_ONLY = 2
-    case TEST_ONLY = 3
+  case TEST_AND_CONFIRM = 1
+  case CONFIRM_ONLY = 2
+  case TEST_ONLY = 3
 }
 
 class DeviceUpgrade {
-    private let id: String
+  private let id: String
 
-    private let bleId: String
-    private let fileURI: String
-    private let options: UpdateOptions
-    private let manager: ReactNativeMcuManagerModule
+  private let bleId: String
+  private let fileURI: String
+  private let options: UpdateOptions
+  private let manager: ReactNativeMcuManagerModule
 
-    private var lastProgress: Int
-    private let logDelegate: McuMgrLogDelegate
+  private var lastProgress: Int
+  private let logDelegate: McuMgrLogDelegate
 
-    private var dfuManager: FirmwareUpgradeManager?
-    private var bleTransport: McuMgrBleTransport?
-    private var promise: Promise?
+  private var dfuManager: FirmwareUpgradeManager?
+  private var bleTransport: McuMgrBleTransport?
+  private var promise: Promise?
 
-    init(
-        id: String, bleId: String, fileURI: String, options: UpdateOptions,
-        manager: ReactNativeMcuManagerModule
-    ) {
-        self.id = id
-        self.bleId = bleId
-        self.fileURI = fileURI
-        self.options = options
+  init(
+    id: String, bleId: String, fileURI: String, options: UpdateOptions,
+    manager: ReactNativeMcuManagerModule
+  ) {
+    self.id = id
+    self.bleId = bleId
+    self.fileURI = fileURI
+    self.options = options
 
-        self.lastProgress = -1
-        self.manager = manager
-        self.logDelegate = UpdateLogDelegate()
+    self.lastProgress = -1
+    self.manager = manager
+    self.logDelegate = UpdateLogDelegate()
+  }
+
+  func startUpgrade(_ promise: Promise) {
+    self.promise = promise
+
+    guard let bleUuid = UUID(uuidString: self.bleId) else {
+      return promise.reject(Exception(name: "UUIDParseError", description: "Failed to parse UUID"))
     }
 
-    func startUpgrade(_ promise: Promise) {
-        self.promise = promise
+    guard let fileUrl = URL(string: self.fileURI) else {
+      return promise.reject(
+        Exception(name: "URIParseError", description: "Failed to parse file URI"))
+    }
 
-        guard let bleUuid = UUID(uuidString: self.bleId) else {
-            return promise.reject(Exception(name: "UUIDParseError", description: "Failed to parse UUID"))
-        }
+    do {
+      let fileHandle = try FileHandle(forReadingFrom: fileUrl)
+      let file = Data(fileHandle.availableData)
+      fileHandle.closeFile()
 
-        guard let fileUrl = URL(string: self.fileURI) else {
-            return promise.reject(Exception(name: "URIParseError", description: "Failed to parse file URI"))
-        }
+      self.bleTransport = McuMgrBleTransport(bleUuid)
+      self.dfuManager = FirmwareUpgradeManager(transporter: self.bleTransport!, delegate: self)
+      let config = FirmwareUpgradeConfiguration(
+        estimatedSwapTime: self.options.estimatedSwapTime,
+        upgradeMode: self.getMode()
+      )
 
+      self.dfuManager!.logDelegate = self.logDelegate
+
+      DispatchQueue.main.async {
         do {
-            let fileHandle = try FileHandle(forReadingFrom: fileUrl)
-            let file = Data(fileHandle.availableData)
-            fileHandle.closeFile()
-
-            self.bleTransport = McuMgrBleTransport(bleUuid)
-            self.dfuManager = FirmwareUpgradeManager(transporter: self.bleTransport!, delegate: self)
-
-            self.dfuManager!.logDelegate = self.logDelegate
-            self.dfuManager!.estimatedSwapTime = self.options.estimatedSwapTime
-            self.dfuManager!.mode = self.getMode()
-
-            try self.dfuManager!.start(data: file as Data)
+          try self.dfuManager!.start(data: file as Data, using: config)
         } catch {
-            promise.reject(UnexpectedException(error))
+          promise.reject(UnexpectedException(error))
         }
+      }
+    } catch {
+      promise.reject(UnexpectedException(error))
+    }
+  }
+
+  func cancel() {
+    if let dfuManager = self.dfuManager {
+      DispatchQueue.main.async {
+        dfuManager.cancel()
+      }
     }
 
-    func cancel() {
-        if let dfuManager = self.dfuManager {
-            dfuManager.cancel()
-        }
+    if let transport = self.bleTransport {
+      transport.close()
+    }
+  }
 
-        if let transport = self.bleTransport {
-            transport.close()
-        }
+  private func getMode() -> FirmwareUpgradeMode {
+    if self.options.upgradeMode == nil {
+      return FirmwareUpgradeMode.testAndConfirm
     }
 
-    private func getMode() -> FirmwareUpgradeMode {
-        if self.options.upgradeMode == nil {
-            return FirmwareUpgradeMode.testAndConfirm
-        }
-
-        guard let jsMode = JSUpgradeMode(rawValue: self.options.upgradeMode!) else {
-            return FirmwareUpgradeMode.testAndConfirm
-        }
-
-        switch jsMode {
-        case .TEST_AND_CONFIRM:
-            return FirmwareUpgradeMode.testAndConfirm
-        case .TEST_ONLY:
-            return FirmwareUpgradeMode.testOnly
-        case .CONFIRM_ONLY:
-            return FirmwareUpgradeMode.confirmOnly
-        }
+    guard let jsMode = JSUpgradeMode(rawValue: self.options.upgradeMode!) else {
+      return FirmwareUpgradeMode.testAndConfirm
     }
+
+    switch jsMode {
+    case .TEST_AND_CONFIRM:
+      return FirmwareUpgradeMode.testAndConfirm
+    case .TEST_ONLY:
+      return FirmwareUpgradeMode.testOnly
+    case .CONFIRM_ONLY:
+      return FirmwareUpgradeMode.confirmOnly
+    }
+  }
 }
 
 class UpdateLogDelegate: McuMgrLogDelegate {
-    func log(_ msg: String, ofCategory category: McuMgrLogCategory, atLevel level: McuMgrLogLevel) {
-        if level.rawValue < McuMgrLogLevel.info.rawValue {
-            return
-        }
-
-        print(msg)
+  func log(_ msg: String, ofCategory category: McuMgrLogCategory, atLevel level: McuMgrLogLevel) {
+    if level.rawValue < McuMgrLogLevel.info.rawValue {
+      return
     }
+
+    print(msg)
+  }
 }
 
 extension DeviceUpgrade: FirmwareUpgradeDelegate {
 
-    /// Called when the upgrade has started.
-    ///
-    /// - parameter controller: The controller that may be used to pause,
-    ///   resume or cancel the upgrade.
-    func upgradeDidStart(controller: FirmwareUpgradeController) {
-        self.manager.updateState(
-            state: [
-                "id": self.id,
-                "state": "STARTED",
-            ]
-        )
+  /// Called when the upgrade has started.
+  ///
+  /// - parameter controller: The controller that may be used to pause,
+  ///   resume or cancel the upgrade.
+  func upgradeDidStart(controller: FirmwareUpgradeController) {
+    self.manager.updateState(
+      state: [
+        "id": self.id,
+        "state": "STARTED",
+      ]
+    )
+  }
+
+  /// Called when the firmware upgrade state has changed.
+  ///
+  /// - parameter previousState: The state before the change.
+  /// - parameter newState: The new state.
+  func upgradeStateDidChange(
+    from previousState: FirmwareUpgradeState, to newState: FirmwareUpgradeState
+  ) {
+    self.manager.updateState(
+      state: [
+        "id": self.id,
+        "state": firmwareEnumToString(e: newState),
+      ]
+    )
+  }
+
+  func firmwareEnumToString(e: FirmwareUpgradeState) -> String {
+    switch e {
+    case .none:
+      return "NONE"
+    case .validate:
+      return "VALIDATE"
+    case .upload:
+      return "UPLOAD"
+    case .test:
+      return "TEST"
+    case .reset:
+      return "RESET"
+    case .confirm:
+      return "CONFIRM"
+    case .success:
+      return "SUCCESS"
+    case .requestMcuMgrParameters:
+      return "REQUEST_MCU_MGR_PARAMETERS"
+    default:
+      return "UNKNOWN"
+    }
+  }
+
+  /// Called when the firmware upgrade has succeeded.
+  func upgradeDidComplete() {
+    self.promise!.resolve(nil)
+  }
+
+  /// Called when the firmware upgrade has failed.
+  ///
+  /// - parameter state: The state in which the upgrade has failed.
+  /// - parameter error: The error.
+  func upgradeDidFail(inState state: FirmwareUpgradeState, with error: Error) {
+    self.promise!.reject(getFirmwareUpgradeException(error))
+  }
+
+  private func getFirmwareUpgradeException(_ error: Error) -> Exception {
+    return Exception(
+      name: "McuMgr_\(String(describing: error.self))", description: error.localizedDescription)
+  }
+
+  /// Called when the firmware upgrade has been cancelled using cancel()
+  /// method. The upgrade may be cancelled only during uploading the image.
+  /// When the image is uploaded, the test and/or confirm commands will be
+  /// sent depending on the mode.
+  func upgradeDidCancel(state: FirmwareUpgradeState) {
+    self.promise!.reject(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled"))
+  }
+
+  /// Called when the upload progress has changed.
+  ///
+  /// - parameter bytesSent: Number of bytes sent so far.
+  /// - parameter imageSize: Total number of bytes to be sent.
+  /// - parameter timestamp: The time that the successful response packet for
+  ///   the progress was received.
+  func uploadProgressDidChange(bytesSent: Int, imageSize: Int, timestamp: Date) {
+    let progress = bytesSent * 100 / imageSize
+
+    if self.lastProgress == progress {
+      return
     }
 
-    /// Called when the firmware upgrade state has changed.
-    ///
-    /// - parameter previousState: The state before the change.
-    /// - parameter newState: The new state.
-    func upgradeStateDidChange(
-        from previousState: FirmwareUpgradeState, to newState: FirmwareUpgradeState
-    ) {
-        self.manager.updateState(
-            state: [
-                "id": self.id,
-                "state": firmwareEnumToString(e: newState),
-            ]
-        )
-    }
-
-    func firmwareEnumToString(e: FirmwareUpgradeState) -> String {
-        switch e {
-        case .none:
-            return "NONE"
-        case .validate:
-            return "VALIDATE"
-        case .upload:
-            return "UPLOAD"
-        case .test:
-            return "TEST"
-        case .reset:
-            return "RESET"
-        case .confirm:
-            return "CONFIRM"
-        case .success:
-            return "SUCCESS"
-        }
-    }
-
-    /// Called when the firmware upgrade has succeeded.
-    func upgradeDidComplete() {
-        self.promise!.resolve(nil)
-    }
-    
-    /// Called when the firmware upgrade has failed.
-    ///
-    /// - parameter state: The state in which the upgrade has failed.
-    /// - parameter error: The error.
-    func upgradeDidFail(inState state: FirmwareUpgradeState, with error: Error) {
-        self.promise!.reject(getFirmwareUpgradeException(error))
-    }
-
-    private func getFirmwareUpgradeException(_ error: Error) -> Exception {
-        switch error {
-        case FirmwareUpgradeError.invalidResponse(let response):
-            return Exception(name: "McuMgrInvalidResponse", description: "Invalid response: \(response.description)")
-        case ImageUploadError.mcuMgrErrorCode(let code), FirmwareUpgradeError.mcuMgrReturnCodeError(let code):
-            return Exception(name: "McuMgrRemoteError", description: code.description, code: "MCU_MGR_REMOTE_ERROR_\(code._code)")
-        default:
-            return Exception(name: "McuMgr_\(String(describing: error.self))", description: error.localizedDescription)
-        }
-    }
-
-    /// Called when the firmware upgrade has been cancelled using cancel()
-    /// method. The upgrade may be cancelled only during uploading the image.
-    /// When the image is uploaded, the test and/or confirm commands will be
-    /// sent depending on the mode.
-    func upgradeDidCancel(state: FirmwareUpgradeState) {
-        self.promise!.reject(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled"))
-    }
-
-    /// Called when the upload progress has changed.
-    ///
-    /// - parameter bytesSent: Number of bytes sent so far.
-    /// - parameter imageSize: Total number of bytes to be sent.
-    /// - parameter timestamp: The time that the successful response packet for
-    ///   the progress was received.
-    func uploadProgressDidChange(bytesSent: Int, imageSize: Int, timestamp: Date) {
-        let progress = bytesSent * 100 / imageSize
-
-        if self.lastProgress == progress {
-            return
-        }
-
-        self.lastProgress = progress
-        self.manager.updateProgress(
-            progress: [
-                "id": self.id,
-                "progress": progress,
-            ]
-        )
-    }
+    self.lastProgress = progress
+    self.manager.updateProgress(
+      progress: [
+        "id": self.id,
+        "progress": progress,
+      ]
+    )
+  }
 }

--- a/ios/ReactNativeMcuManager.podspec
+++ b/ios/ReactNativeMcuManager.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'iOSMcuManagerLibrary', '~> 1.1.0'
+  s.dependency 'iOSMcuManagerLibrary', '~> 1.4.3'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/ios/ReactNativeMcuManagerModule.swift
+++ b/ios/ReactNativeMcuManagerModule.swift
@@ -9,79 +9,79 @@ private let UPGRADE_STATE_EVENTS = "upgradeStateChanged"
 private let UPLOAD_PROGRESS_EVENTS = "uploadProgress"
 
 public class ReactNativeMcuManagerModule: Module {
-    private var upgrades: [String: DeviceUpgrade] = [:]
+  private var upgrades: [String: DeviceUpgrade] = [:]
 
-    public func definition() -> ModuleDefinition {
-        Name(MODULE_NAME)
+  public func definition() -> ModuleDefinition {
+    Name(MODULE_NAME)
 
-        // Defines event names that the module can send to JavaScript.
-        Events(UPGRADE_STATE_EVENTS, UPLOAD_PROGRESS_EVENTS)
+    // Defines event names that the module can send to JavaScript.
+    Events(UPGRADE_STATE_EVENTS, UPLOAD_PROGRESS_EVENTS)
 
-        AsyncFunction("eraseImage") { (bleId: String, promise: Promise) in
-            guard let bleUuid = UUID(uuidString: bleId) else {
-                promise.reject(Exception(name: "UUIDParseError", description: "Failed to parse UUID"))
-                return
-            }
+    AsyncFunction("eraseImage") { (bleId: String, promise: Promise) in
+      guard let bleUuid = UUID(uuidString: bleId) else {
+        promise.reject(Exception(name: "UUIDParseError", description: "Failed to parse UUID"))
+        return
+      }
 
-            let bleTransport = McuMgrBleTransport(bleUuid)
-            let imageManager = ImageManager(transporter: bleTransport)
+      let bleTransport = McuMgrBleTransport(bleUuid)
+      let imageManager = ImageManager(transporter: bleTransport)
 
-            imageManager.erase { (response: McuMgrResponse?, err: Error?) in
-                bleTransport.close()
+      imageManager.erase { (response: McuMgrResponse?, err: Error?) in
+        bleTransport.close()
 
-                if err != nil {
-                    promise.reject(Exception(name: "EraseError", description: err!.localizedDescription))
-                    return
-                }
-
-                promise.resolve(nil)
-                return
-            }
+        if err != nil {
+          promise.reject(Exception(name: "EraseError", description: err!.localizedDescription))
+          return
         }
 
-        Function("createUpgrade") {
-            (
-                id: String, bleId: String, updateFileUriString: String,
-                updateOptions: UpdateOptions
-            ) in
-            upgrades[id] = DeviceUpgrade(
-                id: id, bleId: bleId, fileURI: updateFileUriString, options: updateOptions,
-                manager: self
-            )
-        }
-
-        AsyncFunction("runUpgrade") { (id: String, promise: Promise) in
-            guard let upgrade = self.upgrades[id] else {
-                promise.reject(Exception(name: "UpgradeNotFound", description: "Upgrade object not found"))
-                return
-            }
-
-            upgrade.startUpgrade(promise)
-        }
-
-        Function("cancelUpgrade") { (id: String) in
-            guard let upgrade = self.upgrades[id] else {
-                return
-            }
-
-            upgrade.cancel()
-        }
-
-        Function("destroyUpgrade") { (id: String) in
-            guard let upgrade = self.upgrades[id] else {
-                return
-            }
-
-            upgrade.cancel()
-            self.upgrades[id] = nil
-        }
+        promise.resolve(nil)
+        return
+      }
     }
 
-    func updateProgress(progress: [String: Any?]) {
-        sendEvent(UPLOAD_PROGRESS_EVENTS, progress)
+    Function("createUpgrade") {
+      (
+        id: String, bleId: String, updateFileUriString: String,
+        updateOptions: UpdateOptions
+      ) in
+      upgrades[id] = DeviceUpgrade(
+        id: id, bleId: bleId, fileURI: updateFileUriString, options: updateOptions,
+        manager: self
+      )
     }
 
-    func updateState(state: [String: Any?]) {
-        sendEvent(UPGRADE_STATE_EVENTS, state)
+    AsyncFunction("runUpgrade") { (id: String, promise: Promise) in
+      guard let upgrade = self.upgrades[id] else {
+        promise.reject(Exception(name: "UpgradeNotFound", description: "Upgrade object not found"))
+        return
+      }
+
+      upgrade.startUpgrade(promise)
     }
+
+    Function("cancelUpgrade") { (id: String) in
+      guard let upgrade = self.upgrades[id] else {
+        return
+      }
+
+      upgrade.cancel()
+    }
+
+    Function("destroyUpgrade") { (id: String) in
+      guard let upgrade = self.upgrades[id] else {
+        return
+      }
+
+      upgrade.cancel()
+      self.upgrades[id] = nil
+    }
+  }
+
+  func updateProgress(progress: [String: Any?]) {
+    sendEvent(UPLOAD_PROGRESS_EVENTS, progress)
+  }
+
+  func updateState(state: [String: Any?]) {
+    sendEvent(UPGRADE_STATE_EVENTS, state)
+  }
 }

--- a/ios/UpdateOptions.swift
+++ b/ios/UpdateOptions.swift
@@ -1,6 +1,6 @@
 import ExpoModulesCore
 
 struct UpdateOptions: Record {
-    @Field var estimatedSwapTime: TimeInterval = 0
-    @Field var upgradeMode: Int?
+  @Field var estimatedSwapTime: TimeInterval = 0
+  @Field var upgradeMode: Int?
 }


### PR DESCRIPTION
<!-- Motivation -->
We want to benefit from the bugfixes and QOL changes in the iOS library (including better error handling and some improvements in upload throughput)

<!-- Overview -->
Updating to the latest version of the library means we need to do some changes in how the iOs version of the app works.
Now the start/pause/cancel operations need to be done in the main thread

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Updating versions of the library on a factory test edge
* [x] Using the updated version in the app to update a live edge