### PR TITLE
EXT-FSS2 Added support for React Native 0.73

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -58,13 +58,16 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
-  compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
-  }
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
 
-  kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
   }
 
   namespace "uk.co.playerdata.reactnativemcumanager"


### PR DESCRIPTION
Update build.gradle to set sourceCompatibility and targetCompatibility to JavaVersion.VERSION_11 for AGP versions below 8

<!-- Motivation -->

Added support for React Native 0.73

<!-- Overview -->

The build fails on React Native 0.73 for Android due to a Kotlin version inconsistency. This can be resolved by adhering to the [expo commit](https://github.com/expo/expo/commit/7ec55dfae4942ced223d1a67950e92ebf8f6c7e3) standard for Kotlin versioning

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated
