### PR TITLE
Filters events to the correct Upgrade ID

### DIFF
--- a/ios/DeviceUpgrade.swift
+++ b/ios/DeviceUpgrade.swift
@@ -49,9 +49,9 @@ class DeviceUpgrade {
     }
 
     do {
-      let fileHandle = try FileHandle(forReadingFrom: fileUrl)
-      let file = Data(fileHandle.availableData)
-      fileHandle.closeFile()
+      let binData = try Data(contentsOf: fileUrl)
+      let binHash = try McuMgrImage(data: binData).hash
+      let image = ImageManager.Image(image: 0, hash: binHash, data: binData)
 
       self.bleTransport = McuMgrBleTransport(bleUuid)
       self.dfuManager = FirmwareUpgradeManager(transporter: self.bleTransport!, delegate: self)
@@ -64,7 +64,7 @@ class DeviceUpgrade {
 
       DispatchQueue.main.async {
         do {
-          try self.dfuManager!.start(data: file as Data, using: config)
+          try self.dfuManager!.start(images: [image], using: config)
         } catch {
           promise.reject(UnexpectedException(error))
         }

--- a/ios/ReactNativeMcuManager.podspec
+++ b/ios/ReactNativeMcuManager.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'iOSMcuManagerLibrary', '~> 1.4.3'
+  s.dependency 'iOSMcuManagerLibrary', '~> 1.6.0'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
Resolves https://github.com/PlayerData/roadmap/issues/1694
Ref https://github.com/PlayerData/roadmap/issues/1508

* Upgrades to latest upstream iOS release
* Filters events to the correct Upgrade ID

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I can update EDGEs from iOS
* [x] I can update EDGEs from Android (still)
