### PR TITLE
ci: Correctly generate GitHub release

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -92,6 +92,12 @@ jobs:
     name: Release
     needs: [android-example, ios-example]
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/react-native-mcu-manager/release.config.js
+++ b/react-native-mcu-manager/release.config.js
@@ -1,4 +1,9 @@
 module.exports = {
   branches: [{ name: 'main' }],
-  plugins: ['@semantic-release/commit-analyzer', '@semantic-release/npm'],
+  plugins: [
+    '@semantic-release/commit-analyzer',
+    '@semantic-release/npm',
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/github',
+  ],
 };


### PR DESCRIPTION
At some stage we stopped generating a GitHub release for this repo.

It looks nicer, and we get changelogs.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

