### PR TITLE
Remove all events

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,35 @@ pnpm install @playerdata/react-native-mcu-manager
 
 Run `npx pod-install` after installing the pnpm package.
 
-
 ### Configure for Android
 
 ## Usage
+
 ```ts
-import McuManager, { ProgressEvent, UploadEvents } from '@playerdata/react-native-mcu-manager';
+import McuManager, {
+  UpgradeOptions,
+} from '@playerdata/react-native-mcu-manager';
 
-const onUploadProgress = (progress: ProgressEvent) => {
-  console.log("Upload progress: ", progress.bleId, progress.progress);
+const upgradeOptions: UpgradeOptions = {
+  estimatedSwapTime: 30,
 };
 
-const onUploadStateChanged = (progress: ProgressEvent) => {
-  console.log("Upload state change: ", progress.bleId, progress.state);
+const onUploadProgress = (progress: number) => {
+  console.log('Upload progress: ', progress);
 };
 
-UploadEvents.addListener('uploadProgress', onUploadProgress);
-UploadEvents.addListener('uploadStateChanged', onUploadStateChanged);
+const onUploadStateChanged = (state: string) => {
+  console.log('Upload state change: ', state);
+};
 
 // bluetoothId is a MAC address on Android, and a UUID on iOS
-McuManager.updateDevice(bluetoothId, fileUri)
+McuManager.updateDevice(
+  bluetoothId,
+  fileUri,
+  upgradeOptions,
+  onUploadProgress,
+  onUploadStateChanged
+);
 ```
 
 # Contributing

--- a/example/src/useFirmwareUpdate.ts
+++ b/example/src/useFirmwareUpdate.ts
@@ -28,24 +28,7 @@ const useFirmwareUpdate = (
 
     upgradeRef.current = upgrade;
 
-    const uploadProgressListener = upgrade.addListener(
-      'uploadProgress',
-      ({ progress: newProgress }) => {
-        setProgress(newProgress);
-      }
-    );
-
-    const uploadStateChangedListener = upgrade.addListener(
-      'upgradeStateChanged',
-      ({ state: newState }) => {
-        setState(newState);
-      }
-    );
-
     return function cleanup() {
-      uploadProgressListener.remove();
-      uploadStateChangedListener.remove();
-
       upgrade.cancel();
       upgrade.destroy();
     };

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -5,17 +5,12 @@ import os
 
 private let MODULE_NAME = "ReactNativeMcuManager"
 private let TAG = "McuManagerModule"
-private let UPGRADE_STATE_EVENTS = "upgradeStateChanged"
-private let UPLOAD_PROGRESS_EVENTS = "uploadProgress"
 
 public class ReactNativeMcuManagerModule: Module {
   private var upgrades: [String: DeviceUpgrade] = [:]
 
   public func definition() -> ModuleDefinition {
     Name(MODULE_NAME)
-
-    // Defines event names that the module can send to JavaScript.
-    Events(UPGRADE_STATE_EVENTS, UPLOAD_PROGRESS_EVENTS)
 
     AsyncFunction("eraseImage") { (bleId: String, promise: Promise) in
       guard let bleUuid = UUID(uuidString: bleId) else {

--- a/react-native-mcu-manager/src/Upgrade.ts
+++ b/react-native-mcu-manager/src/Upgrade.ts
@@ -1,5 +1,3 @@
-import { EventEmitter, EventSubscription } from 'expo-modules-core';
-
 import ReactNativeMcuManager from './ReactNativeMcuManagerModule';
 
 export enum UpgradeMode {
@@ -50,33 +48,6 @@ export type FirmwareUpgradeState =
 declare const UpgradeIdSymbol: unique symbol;
 type UpgradeID = string & { [UpgradeIdSymbol]: never };
 
-type UpgradeEvent = 'upgradeStateChanged' | 'uploadProgress';
-
-type UpgradeStateChangedPayload = {
-  id: UpgradeID;
-  state: FirmwareUpgradeState;
-};
-type UploadProgressPayload = { id: UpgradeID; progress: number };
-type UpgradeEventPayload = UpgradeStateChangedPayload & UploadProgressPayload;
-
-type AddUpgradeListener = {
-  (
-    eventType: 'upgradeStateChanged',
-    listener: (event: UpgradeStateChangedPayload) => void
-  ): EventSubscription;
-  (
-    eventType: 'uploadProgress',
-    listener: (event: UploadProgressPayload) => void
-  ): EventSubscription;
-};
-
-type McuManagerEventMap = {
-  upgradeStateChanged: (payload: UpgradeStateChangedPayload) => void;
-  uploadProgress: (payload: UploadProgressPayload) => void;
-};
-
-const McuManagerEvents = new EventEmitter<McuManagerEventMap>();
-
 class Upgrade {
   private id: UpgradeID;
 
@@ -120,16 +91,6 @@ class Upgrade {
 
   cancel = (): void => {
     ReactNativeMcuManager.cancelUpgrade(this.id);
-  };
-
-  addListener: AddUpgradeListener = (
-    eventType: UpgradeEvent,
-    listener: (event: UpgradeEventPayload) => void
-  ): EventSubscription => {
-    return McuManagerEvents.addListener(eventType, (event) => {
-      if (event.id !== this.id) return;
-      listener(event);
-    });
   };
 
   /**


### PR DESCRIPTION
As of https://github.com/PlayerData/react-native-mcu-manager/pull/425, we're not emitting any events. We can remove them all.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

