### PR TITLE
feat: Add bootloader info

### DIFF
--- a/example/src/app/_layout.tsx
+++ b/example/src/app/_layout.tsx
@@ -15,9 +15,10 @@ const RootLayout = () => {
   return (
     <SelectedDeviceProvider value={{ selectedDevice, setSelectedDevice }}>
       <Tabs>
+        <Tabs.Screen name="(home)" options={{ title: 'Home' }} />
         <Tabs.Screen
-          name="(home)"
-          options={{ title: 'Home' }}
+          name="bootloader_info"
+          options={{ title: 'Bootloader Info' }}
         />
         <Tabs.Screen name="update" options={{ title: 'Update' }} />
       </Tabs>

--- a/example/src/app/bootloader_info.tsx
+++ b/example/src/app/bootloader_info.tsx
@@ -1,0 +1,82 @@
+import {
+  BootloaderInfo,
+  bootloaderInfo as rnmcumgrBootloaderInfo,
+} from '@playerdata/react-native-mcu-manager';
+
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useSelectedDevice } from '../context/selectedDevice';
+
+const styles = StyleSheet.create({
+  root: {
+    padding: 16,
+  },
+
+  block: {
+    marginBottom: 16,
+  },
+});
+
+const BootloaderInfoView = () => {
+  const { selectedDevice } = useSelectedDevice();
+
+  const [fetchInProgress, setFetchInProgress] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [bootloaderInfo, setBootloaderInfo] = useState<BootloaderInfo | null>(
+    null
+  );
+
+  const fetchBootloaderInfo = useCallback(async () => {
+    setError(null);
+    setFetchInProgress(true);
+
+    try {
+      setBootloaderInfo(
+        await rnmcumgrBootloaderInfo(selectedDevice?.deviceId || '')
+      );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      setError(errorMessage);
+    } finally {
+      setFetchInProgress(false);
+    }
+  }, [selectedDevice]);
+
+  return (
+    <SafeAreaView>
+      <ScrollView contentContainerStyle={styles.root}>
+        <View style={styles.block}>
+          <Button
+            disabled={fetchInProgress}
+            onPress={() => fetchBootloaderInfo()}
+            title="Fetch Bootloader Info"
+          />
+        </View>
+
+        {error && (
+          <View style={styles.block}>
+            <Text style={{ color: 'red' }}>{error}</Text>
+          </View>
+        )}
+
+        {bootloaderInfo && (
+          <View style={styles.block}>
+            <Text>{JSON.stringify(bootloaderInfo)}</Text>
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default BootloaderInfoView;

--- a/react-native-mcu-manager/ios/BootloaderInfo.swift
+++ b/react-native-mcu-manager/ios/BootloaderInfo.swift
@@ -1,0 +1,7 @@
+import ExpoModulesCore
+
+struct BootloaderInfo: Record {
+    @Field var bootloader: String?
+    @Field var mode: Int?
+    @Field var noDowngrade: Bool?
+}

--- a/react-native-mcu-manager/src/Upgrade.ts
+++ b/react-native-mcu-manager/src/Upgrade.ts
@@ -14,6 +14,13 @@ export enum UpgradeFileType {
 
 export enum UpgradeMode {
   /**
+   * When this flag is set, the manager will immediately send the reset command after
+   * the upload is complete. The device will reboot and will run the new image on its next
+   * boot.
+   */
+  NONE = 0,
+
+  /**
    * This mode is the default and recommended mode for performing upgrades due to it's ability to
    * recover from a bad firmware upgrade. The process for this mode is upload, test, reset, confirm.
    */

--- a/react-native-mcu-manager/src/bootloaderInfo.ts
+++ b/react-native-mcu-manager/src/bootloaderInfo.ts
@@ -1,0 +1,22 @@
+import McuManagerModule from './ReactNativeMcuManagerModule';
+
+export enum MCUBootMode {
+  MCUBOOT_MODE_SINGLE_SLOT = 0,
+  MCUBOOT_MODE_SWAP_USING_SCRATCH = 1,
+  MCUBOOT_MODE_UPGRADE_ONLY = 2,
+  MCUBOOT_MODE_SWAP_USING_MOVE = 3,
+  MCUBOOT_MODE_DIRECT_XIP = 4,
+  MCUBOOT_MODE_DIRECT_XIP_WITH_REVERT = 5,
+  MCUBOOT_MODE_RAM_LOAD = 6,
+  MCUBOOT_MODE_FIRMWARE_LOADER = 7,
+}
+
+export interface BootloaderInfo {
+  bootloader: string | null;
+  mode: MCUBootMode | null;
+  noDowngrade: boolean;
+}
+
+export const bootloaderInfo = McuManagerModule?.bootloaderInfo as (
+  bleId: string
+) => Promise<BootloaderInfo>;

--- a/react-native-mcu-manager/src/index.ts
+++ b/react-native-mcu-manager/src/index.ts
@@ -1,6 +1,7 @@
 import McuManagerModule from './ReactNativeMcuManagerModule';
 import type { FirmwareUpgradeState, UpgradeOptions } from './Upgrade';
 import Upgrade, { UpgradeMode, UpgradeFileType } from './Upgrade';
+import { BootloaderInfo, bootloaderInfo, MCUBootMode } from './bootloaderInfo';
 
 export const eraseImage = McuManagerModule?.eraseImage as (
   bleId: string
@@ -10,5 +11,5 @@ export const resetDevice = McuManagerModule?.resetDevice as (
   bleId: string
 ) => Promise<void>;
 
-export { Upgrade, UpgradeMode, UpgradeFileType };
-export type { FirmwareUpgradeState, UpgradeOptions };
+export { bootloaderInfo, Upgrade, UpgradeMode, UpgradeFileType, MCUBootMode };
+export type { BootloaderInfo, FirmwareUpgradeState, UpgradeOptions };


### PR DESCRIPTION
Allow us to fetch Bootloader info from the MCU.

This includes:
* Bootloader name
* MCUBoot mode
* MCUBoot `noDowngrade` flag


---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I can request information from an MCU
* [x] If the group is disabled, the response is handled gracefully
