### PR TITLE
feat: Add upload only mode

### DIFF
--- a/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
+++ b/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
@@ -18,9 +18,10 @@ import java.io.IOException
 
 val UpgradeModes =
         mapOf(
-                1 to FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM,
-                2 to FirmwareUpgradeManager.Mode.CONFIRM_ONLY,
-                3 to FirmwareUpgradeManager.Mode.TEST_ONLY
+            1 to FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM,
+            2 to FirmwareUpgradeManager.Mode.CONFIRM_ONLY,
+            3 to FirmwareUpgradeManager.Mode.TEST_ONLY,
+            4 to FirmwareUpgradeManager.Mode.NONE,
         )
 
 enum class UpgradeFileType {

--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -5,6 +5,7 @@ enum JSUpgradeMode: Int {
   case TEST_AND_CONFIRM = 1
   case CONFIRM_ONLY = 2
   case TEST_ONLY = 3
+  case UPLOAD_ONLY = 4
 }
 
 enum UpgradeFileType: Int {
@@ -158,6 +159,8 @@ class DeviceUpgrade {
       return FirmwareUpgradeMode.testOnly
     case .CONFIRM_ONLY:
       return FirmwareUpgradeMode.confirmOnly
+    case .UPLOAD_ONLY:
+      return FirmwareUpgradeMode.uploadOnly
     }
   }
 }

--- a/react-native-mcu-manager/src/Upgrade.ts
+++ b/react-native-mcu-manager/src/Upgrade.ts
@@ -14,13 +14,6 @@ export enum UpgradeFileType {
 
 export enum UpgradeMode {
   /**
-   * When this flag is set, the manager will immediately send the reset command after
-   * the upload is complete. The device will reboot and will run the new image on its next
-   * boot.
-   */
-  NONE = 0,
-
-  /**
    * This mode is the default and recommended mode for performing upgrades due to it's ability to
    * recover from a bad firmware upgrade. The process for this mode is upload, test, reset, confirm.
    */
@@ -37,6 +30,13 @@ export enum UpgradeMode {
    * manually as the primary boot image. The process for this mode is upload, test, reset.
    */
   TEST_ONLY = 3,
+
+  /**
+   * When this flag is set, the manager will immediately send the reset command after
+   * the upload is complete. The device will reboot and will run the new image on its next
+   * boot.
+   */
+  UPLOAD_ONLY = 4,
 }
 
 export interface UpgradeOptions {


### PR DESCRIPTION
We claimed to support "NONE" mode, but we didn't actually implement this properly.

This adds support for NONE mode.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I can do a bootloader upgrade successfully
