### PR TITLE
Adding eraseAppSettings to UpgradeOptions TypeScript type

### DIFF
--- a/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
+++ b/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
@@ -28,6 +28,7 @@ class UpdateOptions : Record {
   @Field val estimatedSwapTime: Int = 0
   @Field val upgradeFileType: Int = 0
   @Field val upgradeMode: Int? = null
+  @Field val eraseAppSettings: Boolean? = false
 }
 
 class BootloaderInfo : Record {

--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -114,6 +114,7 @@ class DeviceUpgrade {
       self.dfuManager = FirmwareUpgradeManager(transport: self.bleTransport!, delegate: self)
       let config = FirmwareUpgradeConfiguration(
         estimatedSwapTime: self.options.estimatedSwapTime,
+        eraseAppSettings: self.options.eraseAppSettings,
         upgradeMode: self.getMode()
       )
 

--- a/react-native-mcu-manager/ios/UpdateOptions.swift
+++ b/react-native-mcu-manager/ios/UpdateOptions.swift
@@ -4,4 +4,5 @@ struct UpdateOptions: Record {
     @Field var estimatedSwapTime: TimeInterval = 0
     @Field var upgradeFileType: Int = 0
     @Field var upgradeMode: Int?
+    @Field var eraseAppSettings: Bool = false
 }

--- a/react-native-mcu-manager/src/Upgrade.ts
+++ b/react-native-mcu-manager/src/Upgrade.ts
@@ -57,6 +57,11 @@ export interface UpgradeOptions {
    * @see UpgradeMode
    */
   upgradeMode?: UpgradeMode;
+
+  /**
+   * If true, erase application settings during upgrade (if supported by firmware). Defaults to false.
+   */
+  eraseAppSettings?: boolean;
 }
 
 export type FirmwareUpgradeState =


### PR DESCRIPTION
<!-- Motivation -->
Allowing TypeScript to pass `eraseAppSettings` as part of `UpgradeOptions`, so that we can have more control if we want to erase app settings or not
<!-- Overview -->
Currently, there is no way of erasing App settings as part of the MCU manager firmware update.
This is because this is handled by a boolean `eraseAppSettings` and its set to `false`. 
By allowing it to pass it via `UpgradeOptions`, we can have more control
---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] ...
