### PR TITLE
ci: Fix Android build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -59,7 +59,7 @@ jobs:
           npx expo prebuild --platform android
 
           cd android
-          ./gradlew build
+          ./gradlew app:assembleRelease --no-daemon -Dorg.gradle.logging.level=warn
 
   ios-example:
       name: iOS example app


### PR DESCRIPTION
We're running out of space while doing the Android actions build.

Switching to the `assembleRelease` task avoids producing debug artefacts, and reducing the log level reduces disk space used by logging.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Green build
