### PR TITLE
fix(android): Use any type for function callbacks

### DIFF
--- a/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
+++ b/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
@@ -114,8 +114,8 @@ class ReactNativeMcuManagerModule() : Module() {
         macAddress: String,
         updateFileUriString: String?,
         updateOptions: UpdateOptions,
-        progressCallback: JavaScriptFunction<Unit>,
-        stateCallback: JavaScriptFunction<Unit> ->
+        progressCallback: JavaScriptFunction<Any?>,
+        stateCallback: JavaScriptFunction<Any?> ->
       if (upgrades.contains(id)) {
         throw Exception("Update ID already present")
       }


### PR DESCRIPTION
The current version of expo-modules-core doesn't seem to play nicely with having a Unit return type.

Resolves https://github.com/PlayerData/react-native-mcu-manager/issues/646

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I can see status and upload progress callbacks called successfully on Android.
