### PR TITLE
Block WIP PRs from being merged

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,0 +1,16 @@
+name: "WIP"
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  pull-requests: "read"
+  statuses: "write"
+
+jobs:
+  wip:
+    runs-on: "pd-runner-small"
+    steps:
+      - uses: "wip/action@b52086c74a72e1f699dc34e55cb7e4f84fea2a2c"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
A WIP PR contains "WIP" in the pull request title, and the pipeline blocks it being merged. Once "WIP" is removed from the title, the pipeline allows it to be merged.

https://github.com/PlayerData/roadmap/issues/4630

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [ ] GitHub Checks on this PR
