### PR TITLE
ci: Use trusted publishing

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -95,8 +95,9 @@ jobs:
 
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
       issues: write
+      pull-requests: write
 
     steps:
     - name: Checkout
@@ -116,6 +117,5 @@ jobs:
     - name: Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       working-directory: react-native-mcu-manager
       run: npx semantic-release


### PR DESCRIPTION
See https://docs.npmjs.com/trusted-publishers#configuring-trusted-publishing

I've done the NPM side changes, I think, and removed the old token.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

