### PR TITLE
fix(ios): Add logging to non-upgrade tasks

### DIFF
--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -42,7 +42,7 @@ class DeviceUpgrade {
     self.stateHandler = stateHandler
 
     self.lastProgress = -1
-    self.logDelegate = UpdateLogDelegate()
+    self.logDelegate = RNMcuMgrLogDelegate()
   }
 
   func extractImageFrom(from url: URL, upgradeFileType: UpgradeFileType) throws -> [ImageManager.Image] {
@@ -163,16 +163,6 @@ class DeviceUpgrade {
     case .UPLOAD_ONLY:
       return FirmwareUpgradeMode.uploadOnly
     }
-  }
-}
-
-class UpdateLogDelegate: McuMgrLogDelegate {
-  func log(_ msg: String, ofCategory category: McuMgrLogCategory, atLevel level: McuMgrLogLevel) {
-    if level.rawValue < McuMgrLogLevel.info.rawValue {
-      return
-    }
-
-    print(msg)
   }
 }
 

--- a/react-native-mcu-manager/ios/RNMcuMgrLogDelegate.swift
+++ b/react-native-mcu-manager/ios/RNMcuMgrLogDelegate.swift
@@ -1,0 +1,11 @@
+import iOSMcuManagerLibrary
+
+class RNMcuMgrLogDelegate: McuMgrLogDelegate {
+  func log(_ msg: String, ofCategory category: McuMgrLogCategory, atLevel level: McuMgrLogLevel) {
+    if level.rawValue < McuMgrLogLevel.info.rawValue {
+      return
+    }
+
+    print(msg)
+  }
+}

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -39,7 +39,12 @@ public class ReactNativeMcuManagerModule: Module {
       throw Exception(name: "UUIDParseError", description: "Failed to parse UUID")
     }
 
-    return McuMgrBleTransport(bleUuid)
+    let transport = McuMgrBleTransport(bleUuid)
+
+    let logDelegate = RNMcuMgrLogDelegate()
+    transport.logDelegate = logDelegate
+
+    return transport
   }
 
   private func withTransport<T>(bleId: String, _ block: (McuMgrBleTransport) async throws -> T) async throws -> T {


### PR DESCRIPTION
It's useful to have logging for these tasks as well.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] I see logs while fetching bootloader info
