### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/PlayerData/react-native-mcu-manager/security/code-scanning/4](https://github.com/PlayerData/react-native-mcu-manager/security/code-scanning/4)

To fix the problem, explicitly declare minimal GITHUB_TOKEN permissions for the jobs that currently rely on defaults. The safest change, without altering any existing behavior, is to add a `permissions` block with `contents: read` at the workflow or job level for the build/test jobs that do not need to write to the repository. The `release` job already has a tailored permissions block and should be left as is.

The single best fix here is to add a workflow-level `permissions` block near the top of `.github/workflows/build_and_release.yml` that sets `contents: read`. This will apply to all jobs by default. The existing `permissions` block in the `release` job will override the workflow-level default for that job, preserving its current behavior. This approach ensures that `build`, `android-example`, and `ios-example` all run with read-only repository access while leaving the `release` job unchanged.

Concretely:
- Edit `.github/workflows/build_and_release.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No additional imports or external dependencies are required, and no other lines in this file need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
