### PR TITLE
feat: Allow buffer count parameters to be fetched and set

### DIFF
--- a/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
+++ b/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/DeviceUpgrade.kt
@@ -107,12 +107,18 @@ class DeviceUpgrade(
     }
 
     private fun doUpdate(updateBundleUri: Uri) {
+        val eraseAppSettings = updateOptions.eraseAppSettings
         val estimatedSwapTime = updateOptions.estimatedSwapTime * 1000
         val modeInt = updateOptions.upgradeMode ?: 1
+        val mcubootBufferCount = updateOptions.mcubootBufferCount
         val upgradeFileType = UpgradeFileTypes[updateOptions.upgradeFileType] ?: UpgradeFileType.BIN
         val upgradeMode = UpgradeModes[modeInt] ?: FirmwareUpgradeManager.Mode.TEST_AND_CONFIRM
 
-        val settings = Settings.Builder().setEstimatedSwapTime(estimatedSwapTime).build()
+        val settings = Settings.Builder()
+            .setEstimatedSwapTime(estimatedSwapTime)
+            .setEraseAppSettings(eraseAppSettings)
+            .setWindowCapacity(mcubootBufferCount)
+            .build()
 
         try {
             val images = extractImagesFrom(updateBundleUri, upgradeFileType)

--- a/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
+++ b/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
@@ -25,14 +25,17 @@ private const val MODULE_NAME = "ReactNativeMcuManager"
 private val TAG = "McuManagerModule"
 
 class UpdateOptions : Record {
+  @Field val eraseAppSettings: Boolean = false
   @Field val estimatedSwapTime: Int = 0
+  @Field val mcubootBufferCount: Int = 1
   @Field val upgradeFileType: Int = 0
   @Field val upgradeMode: Int? = null
-  @Field val eraseAppSettings: Boolean? = false
 }
 
 class BootloaderInfo : Record {
   @Field var bootloader: String? = null
+  @Field var bufferCount: Int? = null
+  @Field var bufferSize: Int? = null
   @Field var mode: Int? = null
   @Field var noDowngrade: Boolean = false
 }
@@ -78,7 +81,10 @@ class ReactNativeMcuManagerModule() : Module() {
 
           if (info.bootloader == MCUBOOT) {
             val mcuMgrResult = manager.bootloaderInfo(DefaultManager.BOOTLOADER_INFO_MCUBOOT_QUERY_MODE)
+            val mcuMgrParams = manager.params()
 
+            info.bufferCount = mcuMgrParams.bufCount
+            info.bufferSize = mcuMgrParams.bufSize
             info.mode = mcuMgrResult.mode
             info.noDowngrade = mcuMgrResult.noDowngrade
           }

--- a/react-native-mcu-manager/ios/BootloaderInfo.swift
+++ b/react-native-mcu-manager/ios/BootloaderInfo.swift
@@ -2,6 +2,8 @@ import ExpoModulesCore
 
 struct BootloaderInfo: Record {
     @Field var bootloader: String?
+    @Field var bufferCount: UInt64?
+    @Field var bufferSize: UInt64?
     @Field var mode: Int?
     @Field var noDowngrade: Bool?
 }

--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -115,7 +115,8 @@ class DeviceUpgrade {
       let config = FirmwareUpgradeConfiguration(
         estimatedSwapTime: self.options.estimatedSwapTime,
         eraseAppSettings: self.options.eraseAppSettings,
-        upgradeMode: self.getMode()
+        pipelineDepth: self.options.mcubootBufferCount,
+        upgradeMode: self.getMode(),
       )
 
       self.dfuManager!.logDelegate = self.logDelegate

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -121,6 +121,25 @@ public class ReactNativeMcuManagerModule: Module {
         info.mode = mcubootResponse.mode?.rawValue
         info.noDowngrade = mcubootResponse.noDowngrade
 
+        let mcubootParams: McuMgrParametersResponse = try await withCheckedThrowingContinuation { continuation in
+          manager.params { (mcubootParams: McuMgrParametersResponse?, err: Error?) in
+            if err != nil {
+              continuation.resume(throwing: Exception(name: "BootloaderInfoError", description: err!.localizedDescription))
+              return
+            }
+
+            guard let mcubootParams = mcubootParams else {
+              continuation.resume(throwing: Exception(name: "BootloaderInfoError", description: "MCUboot params null, but no error occurred?"))
+              return
+            }
+
+            continuation.resume(returning: mcubootParams)
+          }
+        }
+
+        info.bufferCount = mcubootParams.bufferCount
+        info.bufferSize = mcubootParams.bufferSize
+
         return info
       }
     }

--- a/react-native-mcu-manager/ios/UpdateOptions.swift
+++ b/react-native-mcu-manager/ios/UpdateOptions.swift
@@ -1,8 +1,9 @@
 import ExpoModulesCore
 
 struct UpdateOptions: Record {
+    @Field var eraseAppSettings: Bool = false
     @Field var estimatedSwapTime: TimeInterval = 0
+    @Field var mcubootBufferCount: Int = 1
     @Field var upgradeFileType: Int = 0
     @Field var upgradeMode: Int?
-    @Field var eraseAppSettings: Bool = false
 }

--- a/react-native-mcu-manager/src/Upgrade.ts
+++ b/react-native-mcu-manager/src/Upgrade.ts
@@ -41,9 +41,25 @@ export enum UpgradeMode {
 
 export interface UpgradeOptions {
   /**
+   * If true, erase application settings during upgrade (if supported by firmware). Defaults to false.
+   */
+  eraseAppSettings?: boolean;
+
+  /**
    * The estimated time, in seconds, that it takes for the target device to swap to the updated image.
    */
   estimatedSwapTime: number;
+
+  /**
+   * This corresponds to the "pipelineDepth" in iOS and "windowCapacity" in Android parameters in
+   * the native libraries.
+   *
+   * It allows to send multiple packets concurrently, without the need to wait for a notification,
+   * which should speed up the upgrade process.
+   *
+   * We think this corresponds to CONFIG_MCUMGR_TRANSPORT_NETBUF_COUNT, but documentation is unclear.
+   */
+  mcubootBufferCount?: number;
 
   /**
    * The type of firmware update file.
@@ -57,11 +73,6 @@ export interface UpgradeOptions {
    * @see UpgradeMode
    */
   upgradeMode?: UpgradeMode;
-
-  /**
-   * If true, erase application settings during upgrade (if supported by firmware). Defaults to false.
-   */
-  eraseAppSettings?: boolean;
 }
 
 export type FirmwareUpgradeState =

--- a/react-native-mcu-manager/src/bootloaderInfo.ts
+++ b/react-native-mcu-manager/src/bootloaderInfo.ts
@@ -13,6 +13,8 @@ export enum MCUBootMode {
 
 export interface BootloaderInfo {
   bootloader: string | null;
+  bufferCount: number | null;
+  bufferSize: number | null;
   mode: MCUBootMode | null;
   noDowngrade: boolean;
 }


### PR DESCRIPTION
Allows buffer count data to be read from the bootloader, then passed back to upgrade options.

Also fixes the wiring of `eraseAppSettings` on Android.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Parameters are correctly read and passed to native library on iOS
* [x] Parameters are correctly read and passed to native library on Android
