### PR TITLE
ci: Allow "work in progress" status write from forks

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,7 +1,9 @@
 name: "WIP"
 on:
-  pull_request_target:
+  pull_request: &pull_request
     types: [opened, synchronize, reopened, edited]
+  pull_request_target:
+    <<: *pull_request
 
 permissions:
   pull-requests: "read"


### PR DESCRIPTION
See https://github.com/PlayerData/react-native-mcu-manager/pull/714 for an example of where this was incorrectly disallowed.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

