### PR TITLE
fix(ios): address correctness issues in native module

### DIFF
--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -1,5 +1,7 @@
 import ExpoModulesCore
+import Foundation
 import iOSMcuManagerLibrary
+import os
 
 enum JSUpgradeMode: Int {
   case TEST_AND_CONFIRM = 1
@@ -86,10 +88,6 @@ class DeviceUpgrade {
       return ImageManager.Image(manifestFile, hash: imageHash, data: imageData)
     }
 
-    try unzippedURLs.forEach { url in
-      try fileManager.removeItem(at: url)
-    }
-
     return images
   }
 
@@ -100,48 +98,60 @@ class DeviceUpgrade {
       return promise.reject(Exception(name: "UUIDParseError", description: "Failed to parse UUID"))
     }
 
-    guard let fileUrl = URL(string: self.fileURI) else {
+    let fileUrl: URL
+    if let parsed = URL(string: self.fileURI), parsed.scheme != nil {
+      fileUrl = parsed
+    } else {
+      fileUrl = URL(fileURLWithPath: self.fileURI)
+    }
+
+    guard let fileType = UpgradeFileType(rawValue: self.options.upgradeFileType) else {
       return promise.reject(
-        Exception(name: "URIParseError", description: "Failed to parse file URI"))
+        Exception(
+          name: "InvalidUpgradeFileType",
+          description: "Unknown upgradeFileType: \(self.options.upgradeFileType)"))
     }
 
     do {
-      let images = try extractImageFrom(
-        from: fileUrl, upgradeFileType: UpgradeFileType(rawValue: self.options.upgradeFileType)!
-      )
+      let images = try extractImageFrom(from: fileUrl, upgradeFileType: fileType)
 
-      self.bleTransport = McuMgrBleTransport(bleUuid)
-      self.dfuManager = FirmwareUpgradeManager(transport: self.bleTransport!, delegate: self)
+      let transport = McuMgrBleTransport(bleUuid)
+      self.bleTransport = transport
+      let manager = FirmwareUpgradeManager(transport: transport, delegate: self)
+      self.dfuManager = manager
       let config = FirmwareUpgradeConfiguration(
         estimatedSwapTime: self.options.estimatedSwapTime,
         eraseAppSettings: self.options.eraseAppSettings,
         pipelineDepth: self.options.mcubootBufferCount,
-        upgradeMode: self.getMode(),
+        upgradeMode: self.getMode()
       )
 
-      self.dfuManager!.logDelegate = self.logDelegate
+      manager.logDelegate = self.logDelegate
 
       DispatchQueue.main.async {
         do {
-          try self.dfuManager!.start(images: images, using: config)
+          try manager.start(images: images, using: config)
         } catch {
+          transport.close()
+          self.dfuManager = nil
+          self.bleTransport = nil
+          self.promise = nil
           promise.reject(UnexpectedException(error))
         }
       }
     } catch {
       promise.reject(UnexpectedException(error))
+      self.promise = nil
     }
   }
 
   func cancel() {
-    if let dfuManager = self.dfuManager {
-      DispatchQueue.main.async {
-        dfuManager.cancel()
-      }
-    }
+    let dfuManager = self.dfuManager
+    let transport = self.bleTransport
 
-    if let transport = self.bleTransport {
-      transport.close()
+    DispatchQueue.main.async {
+      dfuManager?.cancel()
+      transport?.close()
     }
   }
 
@@ -205,14 +215,15 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
       return "SUCCESS"
     case .requestMcuMgrParameters:
       return "REQUEST_MCU_MGR_PARAMETERS"
-    default:
+    @unknown default:
       return "UNKNOWN"
     }
   }
 
   /// Called when the firmware upgrade has succeeded.
   func upgradeDidComplete() {
-    self.promise!.resolve(nil)
+    self.promise?.resolve(nil)
+    self.promise = nil
   }
 
   /// Called when the firmware upgrade has failed.
@@ -220,7 +231,8 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
   /// - parameter state: The state in which the upgrade has failed.
   /// - parameter error: The error.
   func upgradeDidFail(inState state: FirmwareUpgradeState, with error: Error) {
-    self.promise!.reject(getFirmwareUpgradeException(error))
+    self.promise?.reject(getFirmwareUpgradeException(error))
+    self.promise = nil
   }
 
   private func getFirmwareUpgradeException(_ error: Error) -> Exception {
@@ -233,7 +245,8 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
   /// When the image is uploaded, the test and/or confirm commands will be
   /// sent depending on the mode.
   func upgradeDidCancel(state: FirmwareUpgradeState) {
-    self.promise!.reject(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled"))
+    self.promise?.reject(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled"))
+    self.promise = nil
   }
 
   /// Called when the upload progress has changed.

--- a/react-native-mcu-manager/ios/RNMcuMgrLogDelegate.swift
+++ b/react-native-mcu-manager/ios/RNMcuMgrLogDelegate.swift
@@ -1,11 +1,14 @@
 import iOSMcuManagerLibrary
+import os
 
 class RNMcuMgrLogDelegate: McuMgrLogDelegate {
+  private let logger = Logger(subsystem: "ReactNativeMcuManager", category: "McuMgr")
+
   func log(_ msg: String, ofCategory category: McuMgrLogCategory, atLevel level: McuMgrLogLevel) {
     if level.rawValue < McuMgrLogLevel.info.rawValue {
       return
     }
 
-    print(msg)
+    logger.log("\(msg, privacy: .public)")
   }
 }

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -8,7 +8,7 @@ private let MODULE_NAME = "ReactNativeMcuManager"
 private let TAG = "McuManagerModule"
 
 class DisconnectionObserver: ConnectionObserver {
-  private let connectionState = CurrentValueSubject<iOSMcuManagerLibrary.McuMgrTransportState, Never>(iOSMcuManagerLibrary.McuMgrTransportState.disconnected)
+  private let connectionState = PassthroughSubject<iOSMcuManagerLibrary.McuMgrTransportState, Never>()
 
   func transport(_ transport: any iOSMcuManagerLibrary.McuMgrTransport, didChangeStateTo state: iOSMcuManagerLibrary.McuMgrTransportState) {
     connectionState.send(state)
@@ -21,17 +21,19 @@ class DisconnectionObserver: ConnectionObserver {
       stateSink?.cancel()
     }
 
-    try await withCheckedThrowingContinuation { continuation in
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+      var resumed = false
       stateSink = connectionState.sink { state in
-        if state == .disconnected {
-          continuation.resume()
-        }
+        guard !resumed, state == .disconnected else { return }
+        resumed = true
+        continuation.resume()
       }
     }
   }
 }
 
 public class ReactNativeMcuManagerModule: Module {
+  private static let logger = Logger(subsystem: MODULE_NAME, category: TAG)
   private var upgrades: [String: DeviceUpgrade] = [:]
 
   private func getTransport(bleId: String) throws -> McuMgrBleTransport {
@@ -155,6 +157,12 @@ public class ReactNativeMcuManagerModule: Module {
               return
             }
 
+            let smpErr = response?.getError()
+            if smpErr != nil {
+              continuation.resume(throwing: Exception(name: "EraseError", description: smpErr!.localizedDescription))
+              return
+            }
+
             continuation.resume()
           }
         }
@@ -180,7 +188,7 @@ public class ReactNativeMcuManagerModule: Module {
             do {
               let _ = try progressCallback.call(id, progress)
             } catch let err {
-              print("Failed to call progress callback: \(err.localizedDescription)")
+              Self.logger.error("Failed to call progress callback: \(err.localizedDescription, privacy: .public)")
             }
           }
         },
@@ -189,7 +197,7 @@ public class ReactNativeMcuManagerModule: Module {
             do {
               let _ = try stateCallback.call(id, state)
             } catch let err {
-              print("Failed to call state callback: \(err.localizedDescription)")
+              Self.logger.error("Failed to call state callback: \(err.localizedDescription, privacy: .public)")
             }
           }
         }


### PR DESCRIPTION
## Summary
Review of the Swift sources in `react-native-mcu-manager/ios/` surfaced several latent crashes and correctness issues. This PR addresses all of them.

### Bugs fixed
- **DisconnectionObserver double-resume**: `CurrentValueSubject` replayed its seeded `.disconnected` value on every new subscription, so `awaitDisconnect()` returned immediately regardless of real transport state, and a second `.disconnected` event would resume the continuation twice (fatal). Switched to `PassthroughSubject` and guarded the resume with a local flag.
- **Force-unwrapped `UpgradeFileType`**: invalid values from JS would crash the app. Now rejects the promise with `InvalidUpgradeFileType`.
- **Force-unwrapped `self.promise!`** in `upgradeDidComplete` / `upgradeDidFail` / `upgradeDidCancel`: replaced with optional chaining and the promise is cleared after use.
- **`cancel()` race**: `transport.close()` ran synchronously while `dfuManager.cancel()` was dispatched async to main. Both now run on the main queue in order.
- **`fileURI` parsing**: `URL(string:)` silently fails for plain filesystem paths. Falls back to `URL(fileURLWithPath:)` when no scheme is present.
- **Transport leak on start failure**: if `FirmwareUpgradeManager.start` threw, the transport stayed open. Now closed and state cleared.
- **Redundant zip cleanup**: the explicit `forEach removeItem` was redundant with the `defer` that removes the temp directory recursively; removed.

### Minor
- `eraseImage` now checks `response.getError()` for SMP-level errors, matching `resetDevice`.
- `firmwareEnumToString` uses `@unknown default` so new library states are flagged at compile time.
- `print(...)` replaced with `os.Logger` in `RNMcuMgrLogDelegate` and the progress/state callback error paths.

## Test plan
- [ ] Build the example app on iOS
- [ ] Run a full firmware upgrade end-to-end (happy path)
- [ ] Cancel an upgrade mid-upload and confirm the transport closes cleanly
- [ ] Trigger an erase / reset / bootloaderInfo and confirm no regressions
- [ ] Pass an invalid `upgradeFileType` from JS and confirm a rejected promise (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)