### PR TITLE
fix(ios): close transport and fix lifecycle races

### DIFF
--- a/example/src/app/update.tsx
+++ b/example/src/app/update.tsx
@@ -38,7 +38,7 @@ const Update = () => {
   );
 
   const { selectedFile, filePickerError, pickFile } = useFilePicker();
-  const { cancelUpdate, runUpdate, progress, state } = useFirmwareUpdate(
+  const { cancelUpdate, runUpdate, progress, state, error } = useFirmwareUpdate(
     selectedDevice?.deviceId || null,
     selectedFile?.uri || null,
     fileType,
@@ -115,6 +115,7 @@ const Update = () => {
           <Text>
             {state}: {progress}
           </Text>
+          {error && <Text>Error: {error}</Text>}
 
           <Button
             disabled={!selectedFile || !selectedDevice?.deviceId}

--- a/example/src/hooks/useFirmwareUpdate.ts
+++ b/example/src/hooks/useFirmwareUpdate.ts
@@ -13,6 +13,7 @@ const useFirmwareUpdate = (
 ) => {
   const [progress, setProgress] = useState(0);
   const [state, setState] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const upgradeRef = useRef<Upgrade>(null);
 
   useEffect(() => {
@@ -41,6 +42,8 @@ const useFirmwareUpdate = (
   }, [bleId, upgradeFileType, updateFileUri, upgradeMode]);
 
   const runUpdate = async (): Promise<void> => {
+    setError(null);
+
     try {
       if (!upgradeRef.current) {
         throw new Error('No upgrade class - missing BleId or updateFileUri?');
@@ -49,7 +52,7 @@ const useFirmwareUpdate = (
       await upgradeRef.current.runUpgrade();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (ex: any) {
-      setState(ex.message);
+      setError(ex.message);
     }
   };
 
@@ -59,7 +62,7 @@ const useFirmwareUpdate = (
     upgradeRef.current.cancel();
   };
 
-  return { progress, runUpdate, state, cancelUpdate };
+  return { progress, runUpdate, state, error, cancelUpdate };
 };
 
 export default useFirmwareUpdate;

--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -146,10 +146,18 @@ class DeviceUpgrade {
 
       let transport = McuMgrBleTransport(bleUuid)
       let manager = FirmwareUpgradeManager(transport: transport, delegate: self)
-      state.withLock {
-        $0.bleTransport = transport
-        $0.dfuManager = manager
+      let stillActive = state.withLock { state -> Bool in
+        guard state.promise != nil else { return false }
+        state.bleTransport = transport
+        state.dfuManager = manager
+        return true
       }
+
+      guard stillActive else {
+        transport.close()
+        return
+      }
+
       let config = FirmwareUpgradeConfiguration(
         estimatedSwapTime: self.options.estimatedSwapTime,
         eraseAppSettings: self.options.eraseAppSettings,
@@ -174,9 +182,13 @@ class DeviceUpgrade {
   func cancel() {
     let dfuManager = state.withLock { $0.dfuManager }
 
+    guard let dfuManager = dfuManager else {
+      finish(.failure(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled")))
+      return
+    }
+
     DispatchQueue.main.async {
-      dfuManager?.cancel()
-      self.finish(.failure(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled")))
+      dfuManager.cancel()
     }
   }
 

--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -182,14 +182,11 @@ class DeviceUpgrade {
   func cancel() {
     let dfuManager = state.withLock { $0.dfuManager }
 
-    guard let dfuManager = dfuManager else {
-      finish(.failure(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled")))
-      return
+    DispatchQueue.main.async {
+      dfuManager?.cancel()
     }
 
-    DispatchQueue.main.async {
-      dfuManager.cancel()
-    }
+    finish(.failure(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled")))
   }
 
   private func getMode() -> FirmwareUpgradeMode {

--- a/react-native-mcu-manager/ios/DeviceUpgrade.swift
+++ b/react-native-mcu-manager/ios/DeviceUpgrade.swift
@@ -27,9 +27,38 @@ class DeviceUpgrade {
   private var lastProgress: Int
   private let logDelegate: McuMgrLogDelegate
 
-  private var dfuManager: FirmwareUpgradeManager?
-  private var bleTransport: McuMgrBleTransport?
-  private var promise: Promise?
+  private struct State {
+    var dfuManager: FirmwareUpgradeManager?
+    var bleTransport: McuMgrBleTransport?
+    var promise: Promise?
+  }
+
+  private let state = Mutex(State())
+
+  private enum UpgradeResult {
+    case success
+    case failure(Exception)
+  }
+
+  private func finish(_ result: UpgradeResult) {
+    let (promise, transport) = state.withLock { state -> (Promise?, McuMgrBleTransport?) in
+      let promise = state.promise.take()
+      let transport = state.bleTransport.take()
+      state.dfuManager = nil
+      return (promise, transport)
+    }
+
+    transport?.close()
+
+    guard let promise = promise else { return }
+
+    switch result {
+    case .success:
+      promise.resolve(nil)
+    case .failure(let exception):
+      promise.reject(exception)
+    }
+  }
 
   init(
     id: String, bleId: String, fileURI: String, options: UpdateOptions,
@@ -92,7 +121,7 @@ class DeviceUpgrade {
   }
 
   func startUpgrade(_ promise: Promise) {
-    self.promise = promise
+    state.withLock { $0.promise = promise }
 
     guard let bleUuid = UUID(uuidString: self.bleId) else {
       return promise.reject(Exception(name: "UUIDParseError", description: "Failed to parse UUID"))
@@ -116,9 +145,11 @@ class DeviceUpgrade {
       let images = try extractImageFrom(from: fileUrl, upgradeFileType: fileType)
 
       let transport = McuMgrBleTransport(bleUuid)
-      self.bleTransport = transport
       let manager = FirmwareUpgradeManager(transport: transport, delegate: self)
-      self.dfuManager = manager
+      state.withLock {
+        $0.bleTransport = transport
+        $0.dfuManager = manager
+      }
       let config = FirmwareUpgradeConfiguration(
         estimatedSwapTime: self.options.estimatedSwapTime,
         eraseAppSettings: self.options.eraseAppSettings,
@@ -132,26 +163,20 @@ class DeviceUpgrade {
         do {
           try manager.start(images: images, using: config)
         } catch {
-          transport.close()
-          self.dfuManager = nil
-          self.bleTransport = nil
-          self.promise = nil
-          promise.reject(UnexpectedException(error))
+          self.finish(.failure(UnexpectedException(error)))
         }
       }
     } catch {
-      promise.reject(UnexpectedException(error))
-      self.promise = nil
+      self.finish(.failure(UnexpectedException(error)))
     }
   }
 
   func cancel() {
-    let dfuManager = self.dfuManager
-    let transport = self.bleTransport
+    let dfuManager = state.withLock { $0.dfuManager }
 
     DispatchQueue.main.async {
       dfuManager?.cancel()
-      transport?.close()
+      self.finish(.failure(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled")))
     }
   }
 
@@ -222,8 +247,7 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
 
   /// Called when the firmware upgrade has succeeded.
   func upgradeDidComplete() {
-    self.promise?.resolve(nil)
-    self.promise = nil
+    self.finish(.success)
   }
 
   /// Called when the firmware upgrade has failed.
@@ -231,8 +255,7 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
   /// - parameter state: The state in which the upgrade has failed.
   /// - parameter error: The error.
   func upgradeDidFail(inState state: FirmwareUpgradeState, with error: Error) {
-    self.promise?.reject(getFirmwareUpgradeException(error))
-    self.promise = nil
+    self.finish(.failure(getFirmwareUpgradeException(error)))
   }
 
   private func getFirmwareUpgradeException(_ error: Error) -> Exception {
@@ -245,8 +268,7 @@ extension DeviceUpgrade: FirmwareUpgradeDelegate {
   /// When the image is uploaded, the test and/or confirm commands will be
   /// sent depending on the mode.
   func upgradeDidCancel(state: FirmwareUpgradeState) {
-    self.promise?.reject(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled"))
-    self.promise = nil
+    self.finish(.failure(Exception(name: "UpgradeCancelled", description: "Upgrade cancelled")))
   }
 
   /// Called when the upload progress has changed.

--- a/react-native-mcu-manager/ios/Mutex.swift
+++ b/react-native-mcu-manager/ios/Mutex.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Minimal pre-iOS-18 backport of `Synchronization.Mutex`.
+///
+/// Mirrors the standard library's API surface (`init(_:)`, `withLock`,
+/// `withLockIfAvailable`) so that once the deployment target reaches iOS 18
+/// this type can be deleted and replaced with `import Synchronization` with
+/// no call-site changes.
+///
+/// Reference semantics are required: the lock and the value it guards must
+/// stay paired, so this is a `final class` rather than a (copyable) struct.
+///
+/// The underlying lock is **non-reentrant**. Never call `withLock` or
+/// `withLockIfAvailable` from inside another `withLock` body on the same
+/// instance: re-acquiring via `withLock` deadlocks, and via
+/// `withLockIfAvailable` returns `nil`. Keep lock bodies free of call-outs
+/// (continuation resumes, callbacks, re-entrant accessors) for this reason.
+final class Mutex<Value>: @unchecked Sendable {
+  private let lock = NSLock()
+  private var value: Value
+
+  init(_ initialValue: Value) {
+    self.value = initialValue
+  }
+
+  /// Runs `body` with exclusive access to the guarded value.
+  ///
+  /// Blocks until the lock is available. Must not be called re-entrantly
+  /// from within another `withLock`/`withLockIfAvailable` on this instance.
+  func withLock<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body(&value)
+  }
+
+  /// Runs `body` with exclusive access if the lock can be taken without
+  /// waiting; otherwise returns `nil` without running `body`.
+  ///
+  /// Returns `nil` if the lock is held by any thread, including the
+  /// current one (the lock is non-reentrant).
+  func withLockIfAvailable<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result? {
+    guard lock.try() else { return nil }
+    defer { lock.unlock() }
+    return try body(&value)
+  }
+}

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -9,7 +9,7 @@ private let TAG = "McuManagerModule"
 class DisconnectionObserver: ConnectionObserver {
   private struct State {
     var disconnected = false
-    var pendingContinuation: CheckedContinuation<Void, Error>?
+    var pendingContinuations: [CheckedContinuation<Void, Never>] = []
   }
 
   private let state = Mutex(State())
@@ -17,22 +17,26 @@ class DisconnectionObserver: ConnectionObserver {
   func transport(_ transport: any iOSMcuManagerLibrary.McuMgrTransport, didChangeStateTo newState: iOSMcuManagerLibrary.McuMgrTransportState) {
     guard newState == .disconnected else { return }
 
-    let continuation = state.withLock { state -> CheckedContinuation<Void, Error>? in
-      guard !state.disconnected else { return nil }
+    let continuations = state.withLock { state -> [CheckedContinuation<Void, Never>] in
+      guard !state.disconnected else { return [] }
       state.disconnected = true
-      return state.pendingContinuation.take()
+      let pending = state.pendingContinuations
+      state.pendingContinuations = []
+      return pending
     }
 
-    continuation?.resume()
+    for continuation in continuations {
+      continuation.resume()
+    }
   }
 
-  func awaitDisconnect() async throws {
-    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+  func awaitDisconnect() async {
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
       let resumeNow = state.withLock { state -> Bool in
         if state.disconnected {
           return true
         }
-        state.pendingContinuation = continuation
+        state.pendingContinuations.append(continuation)
         return false
       }
 
@@ -70,12 +74,12 @@ public class ReactNativeMcuManagerModule: Module {
       let result = try await block(transport)
 
       transport.close()
-      try await disconnectObserver.awaitDisconnect()
+      await disconnectObserver.awaitDisconnect()
 
       return result
     } catch let error {
       transport.close()
-      try await disconnectObserver.awaitDisconnect()
+      await disconnectObserver.awaitDisconnect()
 
       throw error
     }

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -1,4 +1,3 @@
-import Combine
 import CoreBluetooth
 import ExpoModulesCore
 import iOSMcuManagerLibrary
@@ -8,24 +7,36 @@ private let MODULE_NAME = "ReactNativeMcuManager"
 private let TAG = "McuManagerModule"
 
 class DisconnectionObserver: ConnectionObserver {
-  private let connectionState = PassthroughSubject<iOSMcuManagerLibrary.McuMgrTransportState, Never>()
+  private struct State {
+    var disconnected = false
+    var pendingContinuation: CheckedContinuation<Void, Error>?
+  }
 
-  func transport(_ transport: any iOSMcuManagerLibrary.McuMgrTransport, didChangeStateTo state: iOSMcuManagerLibrary.McuMgrTransportState) {
-    connectionState.send(state)
+  private let state = Mutex(State())
+
+  func transport(_ transport: any iOSMcuManagerLibrary.McuMgrTransport, didChangeStateTo newState: iOSMcuManagerLibrary.McuMgrTransportState) {
+    guard newState == .disconnected else { return }
+
+    let continuation = state.withLock { state -> CheckedContinuation<Void, Error>? in
+      guard !state.disconnected else { return nil }
+      state.disconnected = true
+      return state.pendingContinuation.take()
+    }
+
+    continuation?.resume()
   }
 
   func awaitDisconnect() async throws {
-    var stateSink: AnyCancellable?
-
-    defer {
-      stateSink?.cancel()
-    }
-
     try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-      var resumed = false
-      stateSink = connectionState.sink { state in
-        guard !resumed, state == .disconnected else { return }
-        resumed = true
+      let resumeNow = state.withLock { state -> Bool in
+        if state.disconnected {
+          return true
+        }
+        state.pendingContinuation = continuation
+        return false
+      }
+
+      if resumeNow {
         continuation.resume()
       }
     }


### PR DESCRIPTION
## Motivation

Three iOS connection-lifecycle bugs caused upgrades after the first to fail intermittently: a leaked `McuMgrBleTransport` fought the next attempt over the same peripheral, a subscribe-after-emit race in `awaitDisconnect` could hang reconnects, and cancelling mid-flight orphaned the JS promise. This change makes terminal transitions atomic and deterministic.

## Overview

- `DeviceUpgrade` routes every terminal callback (`upgradeDidComplete`, `Fail`, `Cancel`) through a single locked `finish()` helper that closes the BLE transport exactly once.
- `DisconnectionObserver` replaces its `PassthroughSubject` with a lock-guarded `disconnected` flag plus stored continuation, so `awaitDisconnect` resolves correctly regardless of subscribe/emit ordering.
- `cancel()` rejects any pending promise through the same `finish()` path, ensuring `destroyUpgrade` or cancel during validate/reset/confirm phases never leaks state.

Closes #774

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Run a successful firmware upgrade end-to-end, then immediately start another upgrade on the same peripheral
* [ ] Trigger `destroyUpgrade` during the validate, reset, and confirm phases and confirm the JS promise rejects
* [ ] Force a disconnect mid-upgrade and confirm reconnect proceeds without hangs