### PR TITLE
fix: bump iOSMcuManagerLibrary to 1.14.3 to repair Mac Catalyst DFU

### DIFF
--- a/react-native-mcu-manager/ios/ReactNativeMcuManager.podspec
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManager.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.static_framework = true
 
   s.dependency 'ExpoModulesCore'
-  s.dependency 'iOSMcuManagerLibrary', '1.7.3'
+  s.dependency 'iOSMcuManagerLibrary', '1.14.3'
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {


### PR DESCRIPTION
<!-- Motivation -->

Firmware updates (DFU) on Mac Catalyst hosts fail with `iOSMcuManagerLibrary` 1.7.3. Its BLE transport aborts the entire upgrade with a transient `sendFailed` after a ~105ms CoreBluetooth write-without-response buffer stall.

<!-- Overview -->

Upstream rebuilt the BLE transport across the 1.8–1.14 series. The new reorder-buffer write queue pauses stalled writes and resumes them rather than failing the request, so a transient buffer stall no longer aborts the upgrade. See:

- https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/pull/324
- https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/pull/349
- https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/pull/354
- https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager/pull/357

Bumping the dependency fixes the root cause with no workaround code in this module.

Fixes #785 (transient `sendFailed` aborts DFU on Catalyst).
Fixes #786 (SMP reassembly — the newer library enables it automatically via negotiated MCUmgr parameters).

> Note for consuming apps: 1.14.3 sets default actor isolation to `MainActor`, which may introduce Swift concurrency compile friction. It also brings transitive bumps SwiftCBOR 0.4.7 → 0.6.0 and ZIPFoundation 0.9.19 → 0.9.20.

---------------------

Self Review:

* [ ] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [x] On-device DFU on a Mac Catalyst host against a real Edge device completes successfully
* [ ] Regression check: DFU still works on older firmware without the MCUmgr parameters command