### PR TITLE
chore: ignore expo-managed native modules in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,15 +4,19 @@
   "reviewers": ["team:device-engineering"],
   "packageRules": [
     {
+      "description": "Expo-managed dependencies are upgraded via the Expo SDK (expo install), not Renovate. Covers the expo monorepo plus third-party native modules pinned by bundledNativeModules.json.",
       "matchSourceUrls": ["https://github.com/expo/expo"],
       "enabled": false
     },
     {
-      "matchPackageNames": ["react-native"],
-      "enabled": false
-    },
-    {
-      "matchPackageNames": ["react"],
+      "description": "Expo-managed dependencies are upgraded via the Expo SDK (expo install), not Renovate.",
+      "matchPackageNames": [
+        "react",
+        "react-native",
+        "react-native-reanimated",
+        "react-native-safe-area-context",
+        "react-native-screens"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Renovate already ignored the Expo monorepo (`expo` plus all `expo-*` packages via `matchSourceUrls` for `github.com/expo/expo`) and `react`/`react-native`. But three third-party native modules that Expo also manages through its `bundledNativeModules.json` (the SDK-compatible versions that `expo install` and `expo-doctor` pin) ship from their own repositories, so the source-URL rule never caught them. Renovate was free to bump them out of sync with the Expo SDK.

This adds those three packages to the ignore rule so they stay aligned with the SDK rather than tracking upstream releases independently.

---------------------

- Added `react-native-reanimated`, `react-native-safe-area-context`, and `react-native-screens` to the `matchPackageNames` ignore rule, consolidated with `react`/`react-native`.
- Added `description` fields to the renovate config to explain intent, since JSON has no comments.
- Left `react-native-ble-plx` and `react-native-toast-message` for Renovate to manage, as they are not Expo-managed.

Verified with `renovate-config-validator` (passed). Config-only change to `renovate.json`.

---------------------

Self Review:

* [x] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [x] renovate-config-validator passes