### PR TITLE
chore(deps): hold mcumgr-ble at 2.7.x + harden android CI gradle bootstrap

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -62,6 +62,23 @@ jobs:
           npx expo prebuild --platform android
 
           cd android
+
+          # Pre-fetch the Gradle distribution with retries so a transient
+          # services.gradle.org outage (e.g. HTTP 504) doesn't fail the build.
+          # Only the network bootstrap is retried; the build itself runs once,
+          # so genuine build failures are never masked.
+          for attempt in 1 2 3; do
+            if ./gradlew --version; then
+              break
+            elif [ "$attempt" -eq 3 ]; then
+              echo "Gradle wrapper download failed after 3 attempts"
+              exit 1
+            else
+              echo "Gradle bootstrap attempt $attempt failed; retrying in 15s"
+              sleep 15
+            fi
+          done
+
           ./gradlew app:assembleRelease --no-daemon -Dorg.gradle.logging.level=warn
 
   ios-example:

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,14 @@
         "react-native-screens"
       ],
       "enabled": false
+    },
+    {
+      "description": "mcumgr 2.8.0+ is built with Kotlin 2.3+ (2.9.0 also needs compileSdk 37 / AGP 9.2). Expo 57 / RN 0.86 pins Kotlin 2.1.20 and AGP 8.12, which cannot read that metadata or compile against API 37. Hold at 2.7.x until a future Expo SDK ships a newer Kotlin and AGP 9.",
+      "matchPackageNames": [
+        "no.nordicsemi.android:mcumgr-ble",
+        "no.nordicsemi.android:mcumgr-core"
+      ],
+      "allowedVersions": "<2.8.0"
     }
   ]
 }


### PR DESCRIPTION
## What

- **Holds** `no.nordicsemi.android:mcumgr-ble` / `mcumgr-core` at 2.7.x via Renovate (no dependency version change — stays on the current 2.7.4).
- **Hardens** the Android example CI job: retries only the Gradle wrapper download so a transient `services.gradle.org` outage no longer fails the build.

## Why hold mcumgr-ble

Renovate's bump to 2.9.0 (#811) can't be built on the current toolchain, and neither can 2.8.0:

| Version | Requires | Expo 57 / RN 0.86 provides |
|---|---|---|
| 2.7.4 (current) | Kotlin ≤2.1, compileSdk 36 | Kotlin 2.1.20, AGP 8.12, compileSdk 36 |
| 2.8.0 | **Kotlin 2.3** metadata | ❌ Kotlin 2.1.20 can't read it |
| 2.9.0 | Kotlin 2.4 + **compileSdk 37 / AGP 9.2** | ❌ AGP 8.12 maxes at compileSdk 36 |

2.8.0+ were rebuilt on a newer Nordic toolchain (Kotlin 2.3 / AGP 9). Consuming them would require forcing a Kotlin and/or AGP version beyond what Expo 57 ships — an unsupported override, not a real fix. So we hold at 2.7.x and revisit when a future Expo SDK brings a newer Kotlin and AGP 9. The Renovate rule stops the failing bump PRs from recurring in the meantime.

## Why the CI change

The Android job re-downloads the Gradle distribution every run with no retry, so a single `services.gradle.org` 504 fails the whole job (observed on this branch). The build now retries the wrapper download up to 3 times; `assembleRelease` still runs exactly once, so genuine build failures are not masked.
