### PR TITLE
feat: expose image state

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,43 @@ McuManager.updateDevice(
 );
 ```
 
+## Reading image state
+
+`readImageState(bleId)` exposes the SMP image state read, returning one entry
+per slot with `image`, `slot`, `version`, `hash` (lowercase hex) and the
+`bootable` / `pending` / `confirmed` / `active` / `permanent` flags.
+
+We recommend using it to verify upgrades: the underlying Nordic libraries can
+report a `TEST_AND_CONFIRM` upgrade as successful while the image is not
+durably confirmed (for example when the confirm did not persist, or when the
+device rebooted and reverted before the confirm was sent), in which case
+MCUboot boots the previous firmware on the device's next reboot. After an
+upgrade in a confirming mode resolves, read the image state and only trust the
+update once:
+
+- the primary slot (`image: 0, slot: 0`) reports `active && confirmed` and not
+  `pending` — the one state that survives a reboot in swap-with-revert
+  bootloaders, and
+- no other slot for the same image is `pending` or `permanent` — a staged
+  secondary slot means the device is still running the old firmware and will
+  only swap on a future boot.
+
+If verification fails, retry the upgrade from the start.
+
+```ts
+import { readImageState } from '@playerdata/react-native-mcu-manager';
+
+const slots = await readImageState(bluetoothId);
+
+const primary = slots.find((slot) => slot.image === 0 && slot.slot === 0);
+const staged = slots.some(
+  (slot) => slot.slot !== 0 && (slot.pending || slot.permanent)
+);
+
+const durablyConfirmed =
+  primary?.active && primary.confirmed && !primary.pending && !staged;
+```
+
 # Contributing
 
 Contributions are very welcome!

--- a/example/src/app/_layout.tsx
+++ b/example/src/app/_layout.tsx
@@ -20,6 +20,10 @@ const RootLayout = () => {
           name="bootloader_info"
           options={{ title: 'Bootloader Info' }}
         />
+        <Tabs.Screen
+          name="read_image_state"
+          options={{ title: 'Image State' }}
+        />
         <Tabs.Screen name="update" options={{ title: 'Update' }} />
       </Tabs>
     </SelectedDeviceProvider>

--- a/example/src/app/read_image_state.tsx
+++ b/example/src/app/read_image_state.tsx
@@ -1,0 +1,81 @@
+import {
+  ImageSlotState,
+  readImageState as rnmcumgrReadImageState,
+} from '@playerdata/react-native-mcu-manager';
+
+import React, { useCallback, useState } from 'react';
+import {
+  Button,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+
+import { useSelectedDevice } from '../context/selectedDevice';
+
+const styles = StyleSheet.create({
+  root: {
+    padding: 16,
+  },
+
+  block: {
+    marginBottom: 16,
+  },
+});
+
+const ReadImageStateView = () => {
+  const { selectedDevice } = useSelectedDevice();
+
+  const [fetchInProgress, setFetchInProgress] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [imageState, setImageState] = useState<ImageSlotState[] | null>(null);
+
+  const fetchImageState = useCallback(async () => {
+    setError(null);
+    setFetchInProgress(true);
+
+    try {
+      setImageState(
+        await rnmcumgrReadImageState(selectedDevice?.deviceId || '')
+      );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+
+      setError(errorMessage);
+    } finally {
+      setFetchInProgress(false);
+    }
+  }, [selectedDevice]);
+
+  return (
+    <SafeAreaView>
+      <ScrollView contentContainerStyle={styles.root}>
+        <View style={styles.block}>
+          <Button
+            disabled={fetchInProgress}
+            onPress={() => fetchImageState()}
+            title="Read Image State"
+          />
+        </View>
+
+        {error && (
+          <View style={styles.block}>
+            <Text style={{ color: 'red' }}>{error}</Text>
+          </View>
+        )}
+
+        {imageState &&
+          imageState.map((slot) => (
+            <View key={`${slot.image}-${slot.slot}`} style={styles.block}>
+              <Text>{JSON.stringify(slot, null, 2)}</Text>
+            </View>
+          ))}
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+export default ReadImageStateView;

--- a/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
+++ b/react-native-mcu-manager/android/src/main/java/uk/co/playerdata/reactnativemcumanager/ReactNativeMcuManagerModule.kt
@@ -48,6 +48,18 @@ class BootloaderInfo : Record {
   @Field var noDowngrade: Boolean = false
 }
 
+class ImageSlotState : Record {
+  @Field var image: Int = 0
+  @Field var slot: Int = 0
+  @Field var version: String? = null
+  @Field var hash: String? = null
+  @Field var bootable: Boolean = false
+  @Field var pending: Boolean = false
+  @Field var confirmed: Boolean = false
+  @Field var active: Boolean = false
+  @Field var permanent: Boolean = false
+}
+
 class ReactNativeMcuManagerModule() : Module() {
   private val MCUBOOT = "MCUboot"
 
@@ -157,6 +169,31 @@ class ReactNativeMcuManagerModule() : Module() {
         }
 
         return@withTransport info
+      }
+    }
+
+    AsyncFunction("readImageState") Coroutine { macAddress: String ->
+      withTransport(macAddress) { transport ->
+        try {
+          val imageManager = ImageManager(transport)
+          val response = imageManager.list()
+
+          (response.images ?: emptyArray()).map { imageSlot ->
+            ImageSlotState().apply {
+              image = imageSlot.image
+              slot = imageSlot.slot
+              version = imageSlot.version
+              hash = imageSlot.hash?.joinToString("") { byte -> "%02x".format(byte) }
+              bootable = imageSlot.bootable
+              pending = imageSlot.pending
+              confirmed = imageSlot.confirmed
+              active = imageSlot.active
+              permanent = imageSlot.permanent
+            }
+          }
+        } catch (e: McuMgrException) {
+          throw ReactNativeMcuMgrException.fromMcuMgrException(e)
+        }
       }
     }
 

--- a/react-native-mcu-manager/ios/ImageSlotState.swift
+++ b/react-native-mcu-manager/ios/ImageSlotState.swift
@@ -1,0 +1,13 @@
+import ExpoModulesCore
+
+struct ImageSlotState: Record {
+    @Field var image: UInt64?
+    @Field var slot: UInt64?
+    @Field var version: String?
+    @Field var hash: String?
+    @Field var bootable: Bool?
+    @Field var pending: Bool?
+    @Field var confirmed: Bool?
+    @Field var active: Bool?
+    @Field var permanent: Bool?
+}

--- a/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
+++ b/react-native-mcu-manager/ios/ReactNativeMcuManagerModule.swift
@@ -184,6 +184,48 @@ public class ReactNativeMcuManagerModule: Module {
       }
     }
 
+    AsyncFunction("readImageState") { (bleId: String) in
+      try await withTransport(bleId: bleId) { (transport: McuMgrBleTransport) in
+        let imageManager = ImageManager(transport: transport)
+
+        let response: McuMgrImageStateResponse = try await withCheckedThrowingContinuation { continuation in
+          imageManager.list { (response: McuMgrImageStateResponse?, err: Error?) in
+            if err != nil {
+              continuation.resume(throwing: Exception(name: "ReadImageStateError", description: err!.localizedDescription))
+              return
+            }
+
+            let smpErr = response?.getError()
+            if smpErr != nil {
+              continuation.resume(throwing: Exception(name: "ReadImageStateError", description: smpErr!.localizedDescription))
+              return
+            }
+
+            guard let response = response else {
+              continuation.resume(throwing: Exception(name: "ReadImageStateError", description: "Image state response null, but no error occurred?"))
+              return
+            }
+
+            continuation.resume(returning: response)
+          }
+        }
+
+        return (response.images ?? []).map { slot -> ImageSlotState in
+          let state = ImageSlotState()
+          state.image = slot.image
+          state.slot = slot.slot
+          state.version = slot.version
+          state.hash = slot.hash.map { String(format: "%02x", $0) }.joined()
+          state.bootable = slot.bootable
+          state.pending = slot.pending
+          state.confirmed = slot.confirmed
+          state.active = slot.active
+          state.permanent = slot.permanent
+          return state
+        }
+      }
+    }
+
     AsyncFunction("eraseImage") { (bleId: String) in
       try await withTransport(bleId: bleId) { (transport: McuMgrBleTransport) in
         let imageManager = ImageManager(transport: transport)

--- a/react-native-mcu-manager/src/index.ts
+++ b/react-native-mcu-manager/src/index.ts
@@ -2,6 +2,7 @@ import McuManagerModule from './ReactNativeMcuManagerModule';
 import type { FirmwareUpgradeState, UpgradeOptions } from './Upgrade';
 import Upgrade, { UpgradeMode, UpgradeFileType } from './Upgrade';
 import { BootloaderInfo, bootloaderInfo, MCUBootMode } from './bootloaderInfo';
+import { ImageSlotState, readImageState } from './readImageState';
 
 export const eraseImage = McuManagerModule?.eraseImage as (
   bleId: string
@@ -11,5 +12,17 @@ export const resetDevice = McuManagerModule?.resetDevice as (
   bleId: string
 ) => Promise<void>;
 
-export { bootloaderInfo, Upgrade, UpgradeMode, UpgradeFileType, MCUBootMode };
-export type { BootloaderInfo, FirmwareUpgradeState, UpgradeOptions };
+export {
+  bootloaderInfo,
+  readImageState,
+  Upgrade,
+  UpgradeMode,
+  UpgradeFileType,
+  MCUBootMode,
+};
+export type {
+  BootloaderInfo,
+  FirmwareUpgradeState,
+  ImageSlotState,
+  UpgradeOptions,
+};

--- a/react-native-mcu-manager/src/readImageState.ts
+++ b/react-native-mcu-manager/src/readImageState.ts
@@ -1,0 +1,24 @@
+import McuManagerModule from './ReactNativeMcuManagerModule';
+
+export interface ImageSlotState {
+  image: number;
+  slot: number;
+  version: string | null;
+  /** SHA-256 of the image, as a lowercase hex string. */
+  hash: string;
+  bootable: boolean;
+  pending: boolean;
+  confirmed: boolean;
+  active: boolean;
+  permanent: boolean;
+}
+
+/**
+ * Read the MCUboot image state (SMP image state read) for every slot on the
+ * device. Use after an upgrade to verify the running image is durably
+ * confirmed: a slot that is `active` but not `confirmed` will be reverted by
+ * MCUboot on the device's next reboot.
+ */
+export const readImageState = McuManagerModule?.readImageState as (
+  bleId: string
+) => Promise<ImageSlotState[]>;


### PR DESCRIPTION
<!-- Motivation -->

Upgrades run in `TEST_AND_CONFIRM` mode can report success while the device is about to revert: on the next reboot, MCUboot swaps back to the previous firmware even though `runUpgrade` resolved cleanly. The underlying Nordic iOS library (1.14.3) treats a slot that is merely `active` (running but unconfirmed) as confirmed, silently skips confirmation when no slot hash matches the uploaded image, and — when the device has already reverted — confirms the secondary slot and reports success without a reset while the old firmware is still running.

Consumers currently have no way to detect any of this: the wrapper exposes no image state, so a resolved upgrade is indistinguishable from a soon-to-revert one.

<!-- Overview -->

- Adds a `readImageState(bleId)` API exposing the SMP image state read on both platforms: one entry per slot with `image`, `slot`, `version`, `hash` (lowercase hex) and the `bootable`/`pending`/`confirmed`/`active`/`permanent` flags
- Documents the recommended post-upgrade verification pattern in the README: require the primary slot `active && confirmed && !pending` with no staged secondary slot before trusting an upgrade, and retry otherwise
- Adds an example app screen exercising `readImageState`

Verification is deliberately left to the consumer (in JavaScript) rather than performed inside the native upgrade completion callbacks: the device reboots around the test/reset phases, so an SMP read from within the completion callback races the reboot, whereas a consumer-side read establishes a fresh connection under its own timeout and retry policy.

---------------------

Self Review:

* [x] Appropriate test coverage
* [x] Relevant Documentation updated

Smoke Tests:

* [x] Run a real `TEST_AND_CONFIRM` upgrade against an MCUboot device via the example app, then use the read image state screen and check the running slot reports `active && confirmed` with the expected hash
* [x] Power-cycle the device and confirm it is still running the new firmware
