### PR TITLE
ci: pin pnpm to 11.7.0

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          version: 11.7.0
           run_install: true
 
       - name: Build
@@ -53,7 +53,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          version: 11.7.0
           run_install: true
 
       - name: Making sure the android example app builds
@@ -80,7 +80,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          version: 11.7.0
           run_install: true
 
       - name: Making sure the ios example app builds
@@ -114,7 +114,7 @@ jobs:
     - name: Setup PNPM
       uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
       with:
-        version: 11
+        version: 11.7.0
         run_install: true
 
     - name: Release

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
-          version: 11
+          version: 11.7.0
           run_install: true
 
       - name: Lint


### PR DESCRIPTION
<!-- Motivation -->

Every `Build and Release` run on `main` (and any new PR run) currently fails in the `Setup PNPM` step before any project step executes: `pnpm/action-setup` with `version: 11` self-updates to the latest 11.x, and pnpm 11.12.0's self-installer crashes with `Cannot use 'in' operator to search for 'integrity' in undefined`. This has blocked the release of the merged #819 (its unreleased `feat` commits will publish on the next successful main build).

<!-- Overview -->

- Pin `version: 11.7.0` (the last version proven working in this repo's CI) in `build_and_release.yml` and `lint.yml`

---------------------

Self Review:

* [ ] Appropriate test coverage
* [ ] Relevant Documentation updated

Smoke Tests:

* [ ] CI on this PR gets past `Setup PNPM` and runs to completion
